### PR TITLE
using debug for logging worker exception because we can't assume a provi...

### DIFF
--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -32,7 +32,7 @@ def get_service_name(service_cls):
 def log_worker_exception(worker_ctx, exc):
     if isinstance(exc, RemoteError):
         exc = "RemoteError"
-    _log.error('error handling worker %s: %s', worker_ctx, exc, exc_info=True)
+    _log.debug('error handling worker %s: %s', worker_ctx, exc, exc_info=True)
 
 
 class WorkerContextBase(object):


### PR DESCRIPTION
...der isn't handling it and thus we can't treat it as an error
