### PR TITLE
Signal-based: Stop all containers in a runner after a single container is killed

### DIFF
--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -12,6 +12,7 @@ import greenlet
 from nameko.dependencies import get_dependencies, DependencySet
 from nameko.exceptions import RemoteError
 from nameko.logging import log_time
+from nameko.utils import Signal
 
 WORKER_CALL_ID_STACK_KEY = 'call_id_stack'
 
@@ -135,6 +136,7 @@ class ManagedThreadContainer(object):
         self._active_threads = set()
         self._being_killed = False
         self._died = Event()
+        self.killed = Signal()
 
     def stop(self):
         """ Stop the container gracefully.
@@ -187,6 +189,10 @@ class ManagedThreadContainer(object):
 
         self._kill_active_threads()
         self._died.send_exception(exc)
+
+        # We've killed the container now.
+        self._being_killed = False
+        self.killed.fire(exc)
 
     def wait(self):
         """ Block until the container has been stopped.

--- a/nameko/runners.py
+++ b/nameko/runners.py
@@ -57,12 +57,18 @@ class ServiceRunner(object):
         A new container is created for each service using the container
         class provided in the __init__ method.
 
-        All containers are started concurently and the method will block
+        All containers are started concurrently and the method will block
         until all have completed their startup routine.
+
+        If any single container is killed, the runner will stop all other
+        containers.
         """
         _log.info('starting services: %s', self.service_names)
 
         SpawningProxy(self.containers).start()
+
+        for c in self.containers:
+            c.killed.connect(lambda exc: self.stop())
 
         _log.info('services started: %s', self.service_names)
 

--- a/nameko/utils.py
+++ b/nameko/utils.py
@@ -48,3 +48,20 @@ def try_wraps(func):
             return inner
 
     return try_to_wrap
+
+
+class Signal(object):
+    def __init__(self):
+        """ Tracks observer functions to call when the signal is fired. """
+        self._handlers = []
+
+    def connect(self, handler):
+        """ Connect an additional handler to this signal. """
+        self._handlers.append(handler)
+
+    def fire(self, *args, **kwargs):
+        """ Fires the signal, calling all registered handlers with the
+        arguments provided.
+        """
+        for handler in self._handlers:
+            handler(*args, **kwargs)

--- a/test/test_service_runner.py
+++ b/test/test_service_runner.py
@@ -7,6 +7,7 @@ from nameko.standalone.rpc import rpc_proxy
 from nameko.rpc import rpc
 from nameko.runners import ServiceRunner
 from nameko.testing.utils import assert_stops_raising
+from nameko.utils import Signal
 
 
 class TestService1(object):
@@ -46,6 +47,7 @@ def test_runner_lifecycle():
             self.service_name = service_cls.__name__
             self.service_cls = service_cls
             self.worker_ctx_cls = worker_ctx_cls
+            self.killed = Signal()
 
         def start(self):
             events.append(('start', self.service_cls.name, self.service_cls))
@@ -97,7 +99,7 @@ def test_runner_lifecycle():
 def test_runner_waits_raises_error():
     class Container(object):
         def __init__(self, service_cls, worker_ctx_cls, config):
-            pass
+            self.killed = Signal()
 
         def start(self):
             pass


### PR DESCRIPTION
After a container is killed, fire a signal out to any interested parties. Register a listener to that signal from the runner to stop all services.
