### PR TITLE
First do task and then wait for the next one

### DIFF
--- a/nameko/timer.py
+++ b/nameko/timer.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from logging import getLogger
 import time
 
-from eventlet import Timeout
 from eventlet.event import Event
 
 from nameko.extensions import Entrypoint
@@ -13,11 +12,12 @@ _log = getLogger(__name__)
 class Timer(Entrypoint):
     def __init__(self, interval, eager=False):
         """
-        Timer entrypoint implementation. Fires every :attr:`interval`
-        seconds.
+        Timer entrypoint. Fires every `interval` seconds or as soon as the previous
+        worker completes if that took longer.
 
-        The implementation sleeps first,i.e. does not fire at time 0.
-        If you want to fire at time 0 (fire first) set :attr:`eager`=True
+        The default behaviour is to wait `interval` seconds before firing for the
+        first time. If you want the entrypoint to fire as soon as the service starts,
+        pass `eager=True`.
 
         Example::
 
@@ -33,7 +33,8 @@ class Timer(Entrypoint):
         """
         self.interval = interval
         self.eager = eager
-        self.should_stop = Event()
+        self.should_stop = False
+        self.event = Event()
         self.gt = None
 
     def start(self):
@@ -42,7 +43,7 @@ class Timer(Entrypoint):
 
     def stop(self):
         _log.debug('stopping %s', self)
-        self.should_stop.send(True)
+        self.should_stop = True
         self.gt.wait()
 
     def kill(self):
@@ -51,25 +52,28 @@ class Timer(Entrypoint):
 
     def _run(self):
         """ Runs the interval loop. """
-
         sleep_time = 0 if self.eager else self.interval
 
         while True:
             # sleep for `sleep_time`, unless `should_stop` fires, in which
             # case we leave the while loop and stop entirely
-            with Timeout(sleep_time, exception=False):
-                self.should_stop.wait()
-                break
+            time.sleep(sleep_time)
 
             start = time.time()
 
             self.handle_timer_tick()
+
+            self.event.wait()
+            self.event.reset()
 
             elapsed_time = (time.time() - start)
 
             # next time, sleep however long is left of our interval, taking
             # off the time we took to run
             sleep_time = max(self.interval - elapsed_time, 0)
+
+            if self.should_stop:
+                break
 
     def handle_timer_tick(self):
         args = ()
@@ -78,9 +82,14 @@ class Timer(Entrypoint):
         # Note that we don't catch ContainerBeingKilled here. If that's raised,
         # there is nothing for us to do anyway. The exception bubbles, and is
         # caught by :meth:`Container._handle_thread_exited`, though the
-        # triggered `kill` is a no-op, since the container is alredy
+        # triggered `kill` is a no-op, since the container is already
         # `_being_killed`.
-        self.container.spawn_worker(self, args, kwargs)
+        self.container.spawn_worker(
+            self, args, kwargs, handle_result=self.handle_result)
+
+    def handle_result(self, worker_ctx, result, exc_info):
+        self.event.send(result, exc_info)
+        return result, exc_info
 
 
 timer = Timer.decorator

--- a/nameko/timer.py
+++ b/nameko/timer.py
@@ -11,12 +11,13 @@ _log = getLogger(__name__)
 
 
 class Timer(Entrypoint):
-    def __init__(self, interval):
+    def __init__(self, interval, eager=False):
         """
-        Timer entrypoint implementation. Fires every :attr:`self.interval`
+        Timer entrypoint implementation. Fires every :attr:`interval`
         seconds.
 
-        The implementation sleeps first, i.e. does not fire at time 0.
+        The implementation sleeps first,i.e. does not fire at time 0.
+        If you want to fire at time 0 (fire first) set :attr:`eager`=True
 
         Example::
 
@@ -31,6 +32,7 @@ class Timer(Entrypoint):
 
         """
         self.interval = interval
+        self.eager = eager
         self.should_stop = Event()
         self.gt = None
 
@@ -50,7 +52,7 @@ class Timer(Entrypoint):
     def _run(self):
         """ Runs the interval loop. """
 
-        sleep_time = self.interval
+        sleep_time = 0 if self.eager else self.interval
 
         while True:
             # sleep for `sleep_time`, unless `should_stop` fires, in which

--- a/nameko/timer.py
+++ b/nameko/timer.py
@@ -12,12 +12,12 @@ _log = getLogger(__name__)
 class Timer(Entrypoint):
     def __init__(self, interval, eager=False):
         """
-        Timer entrypoint. Fires every `interval` seconds or as soon as the previous
-        worker completes if that took longer.
+        Timer entrypoint. Fires every `interval` seconds or as soon as
+        the previous worker completes if that took longer.
 
-        The default behaviour is to wait `interval` seconds before firing for the
-        first time. If you want the entrypoint to fire as soon as the service starts,
-        pass `eager=True`.
+        The default behaviour is to wait `interval` seconds
+        before firing for the first time. If you want the entrypoint
+        to fire as soon as the service starts, pass `eager=True`.
 
         Example::
 
@@ -34,7 +34,7 @@ class Timer(Entrypoint):
         self.interval = interval
         self.eager = eager
         self.should_stop = False
-        self.event = Event()
+        self.worker_complete = Event()
         self.gt = None
 
     def start(self):
@@ -63,8 +63,8 @@ class Timer(Entrypoint):
 
             self.handle_timer_tick()
 
-            self.event.wait()
-            self.event.reset()
+            self.worker_complete.wait()
+            self.worker_complete.reset()
 
             elapsed_time = (time.time() - start)
 
@@ -88,7 +88,7 @@ class Timer(Entrypoint):
             self, args, kwargs, handle_result=self.handle_result)
 
     def handle_result(self, worker_ctx, result, exc_info):
-        self.event.send(result, exc_info)
+        self.worker_complete.send()
         return result, exc_info
 
 

--- a/test/test_timers.py
+++ b/test/test_timers.py
@@ -1,5 +1,4 @@
 import eventlet
-from eventlet import Timeout
 
 from mock import Mock
 
@@ -21,12 +20,13 @@ def test_provider(interval=0.1, eager=False):
     assert timer.eager == eager
 
     with wait_for_call(1, container.spawn_worker) as spawn_worker:
-        with Timeout(1):
-            timer.stop()
+        timer.handle_result(None, None, None)
+        timer.stop()
 
     # the timer should have stopped and should only have spawned
     # a single worker
-    spawn_worker.assert_called_once_with(timer, (), {})
+    spawn_worker.assert_called_once_with(
+        timer, (), {}, handle_result=timer.handle_result)
     assert timer.gt.dead
 
 

--- a/test/test_timers.py
+++ b/test/test_timers.py
@@ -8,16 +8,17 @@ from nameko.timer import Timer
 from nameko.testing.utils import wait_for_call
 
 
-def test_provider():
+def test_provider(interval=0.1, eager=False):
     container = Mock(spec=ServiceContainer)
     container.service_name = "service"
     container.spawn_managed_thread = eventlet.spawn
 
-    timer = Timer(interval=0.1).bind(container, "method")
+    timer = Timer(interval, eager).bind(container, "method")
     timer.setup()
     timer.start()
 
-    assert timer.interval == 0.1
+    assert timer.interval == interval
+    assert timer.eager == eager
 
     with wait_for_call(1, container.spawn_worker) as spawn_worker:
         with Timeout(1):
@@ -27,6 +28,10 @@ def test_provider():
     # a single worker
     spawn_worker.assert_called_once_with(timer, (), {})
     assert timer.gt.dead
+
+
+def test_provider_param_eager():
+    test_provider(interval=5, eager=True)
 
 
 def test_stop_timer_immediatly():


### PR DESCRIPTION
I think this change is needed for testing and observation of Timer service after deploy on production server when there is defined long time between tasks.
