### PR TITLE
regression test for #368

### DIFF
--- a/nameko/web/server.py
+++ b/nameko/web/server.py
@@ -82,11 +82,14 @@ class WebServer(ProviderCollector, SharedExtension):
     def process_request(self, sock, address):
         try:
             self._serv.process_request((sock, address))
-        except OSError:
+        except OSError as exc:
             # OSError("raw readinto() returned invalid length")
-            # can be raised when a client disconnects very early.
+            # can be raised when a client disconnects very early as a result
+            # of an eventlet bug: https://github.com/eventlet/eventlet/pull/353
             # See https://github.com/onefinestay/nameko/issues/368
-            pass
+            if "raw readinto() returned invalid length" in str(exc):
+                return
+            raise
 
     def start(self):
         if not self._starting:

--- a/nameko/web/server.py
+++ b/nameko/web/server.py
@@ -76,8 +76,17 @@ class WebServer(ProviderCollector, SharedExtension):
             sock, addr = self._sock.accept()
             sock.settimeout(self._serv.socket_timeout)
             self.container.spawn_managed_thread(
-                partial(self._serv.process_request, (sock, addr))
+                partial(self.process_request, sock, addr)
             )
+
+    def process_request(self, sock, address):
+        try:
+            self._serv.process_request((sock, address))
+        except OSError:
+            # OSError("raw readinto() returned invalid length")
+            # can be raised when a client disconnects very early.
+            # See https://github.com/onefinestay/nameko/issues/368
+            pass
 
     def start(self):
         if not self._starting:

--- a/test/web/test_server.py
+++ b/test/web/test_server.py
@@ -40,6 +40,27 @@ def test_broken_pipe(
     assert web_session.get('/').text == ''
 
 
+def test_other_socket_error(
+    container_factory, web_config, web_config_port, web_session
+):
+    container = container_factory(ExampleService, web_config)
+    container.start()
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect(('127.0.0.1', web_config_port))
+
+    with patch.object(BaseHTTPServer.BaseHTTPRequestHandler, 'finish') as fin:
+        fin.side_effect = socket.error('boom')
+        s.sendall(b'GET / \r\n\r\n')
+        s.recv(10)
+        s.close()
+
+    # takes down container
+    with pytest.raises(socket.error) as exc:
+        container.wait()
+    assert 'boom' in str(exc)
+
+
 def test_client_disconnect_os_error(
     container_factory, web_config, web_config_port, web_session
 ):
@@ -59,30 +80,6 @@ def test_client_disconnect_os_error(
 
     # server should still work
     assert web_session.get('/').text == ''
-
-
-def test_other_error(
-    container_factory, web_config, web_config_port, web_session
-):
-    container = container_factory(ExampleService, web_config)
-    container.start()
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect(('127.0.0.1', web_config_port))
-
-    class OtherError(Exception):
-        pass
-
-    with patch.object(BaseHTTPServer.BaseHTTPRequestHandler, 'finish') as fin:
-        fin.side_effect = OtherError('boom')
-        s.sendall(b'GET / \r\n\r\n')
-        s.recv(10)
-        s.close()
-
-    # takes down container
-    with pytest.raises(OtherError) as exc:
-        container.wait()
-    assert 'boom' in str(exc)
 
 
 @pytest.mark.parametrize(['source', 'result'], [


### PR DESCRIPTION
Fixes #368 

@davidszotten the fix required a change to a test which seemed to explicitly expect a `socket.error` to take down the container (called `test_other_error`). What was the intent of that test?
