### PR TITLE
Perform the whole worker lifecycle in the worker thread

### DIFF
--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -432,14 +432,17 @@ class ServiceContainer(object):
             setattr(worker_ctx.service, provider.attr_name, dependency)
 
     def _worker_setup(self, worker_ctx):
-        self.dependencies.all.worker_setup(worker_ctx)
+        for provider in self.dependencies:
+            provider.worker_setup(worker_ctx)
 
     def _worker_result(self, worker_ctx, result, exc_info):
         _log.debug('signalling result for %s', worker_ctx)
-        self.dependencies.all.worker_result(worker_ctx, result, exc_info)
+        for provider in self.dependencies:
+            provider.worker_result(worker_ctx, result, exc_info)
 
     def _worker_teardown(self, worker_ctx):
-        self.dependencies.all.worker_teardown(worker_ctx)
+        for provider in self.dependencies:
+            provider.worker_teardown(worker_ctx)
 
     def _kill_worker_threads(self):
         """ Kill any currently executing worker threads.

--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -391,6 +391,7 @@ class ServiceContainer(object):
 
         with _log_time('ran worker %s', worker_ctx):
 
+            self._inject_dependencies(worker_ctx)
             self._worker_setup(worker_ctx)
 
             result = exc_info = None
@@ -425,10 +426,12 @@ class ServiceContainer(object):
 
                 self._worker_teardown(worker_ctx)
 
+    def _inject_dependencies(self, worker_ctx):
+        for provider in self.dependencies:
+            dependency = provider.get_dependency(worker_ctx)
+            setattr(worker_ctx.service, provider.attr_name, dependency)
+
     def _worker_setup(self, worker_ctx):
-        # TODO: when we have better parallelization than ``spawningset``,
-        # do this injection inline
-        self.dependencies.all.inject(worker_ctx)
         self.dependencies.all.worker_setup(worker_ctx)
 
     def _worker_result(self, worker_ctx, result, exc_info):

--- a/nameko/extensions.py
+++ b/nameko/extensions.py
@@ -151,13 +151,6 @@ class DependencyProvider(Extension):
         an object to be injected into the worker instance by the container.
         """
 
-    def inject(self, worker_ctx):
-        """ TODO when we have better parallelization than ``spawningset``,
-            do this injection in the container
-        """
-        dependency = self.get_dependency(worker_ctx)
-        setattr(worker_ctx.service, self.attr_name, dependency)
-
     def worker_result(self, worker_ctx, result=None, exc_info=None):
         """ Called with the result of a service worker execution.
 


### PR DESCRIPTION
There are two changes here, in two commits:

1. Move dependency injection into the container, rather than delegated to the dependency provider. 

2. Remove the use of the spawning set during `worker_setup`, `worker_result` and `worker_teardown`, so these all happen in the same (worker) thread.

The motivation for this change is https://github.com/mattbennett/nameko-sentry/pull/7 (specifically the last commit). Running the worker lifecycle methods in the same thread means that thread-locals are shared, which Raven relies upon.

The downside is that the lifecycle of an individual worker may potentially be slower -- for example, if there is more than one dependency with an onerous and I/O bound setup or teardown, they will no longer be run in parallel.

On the other hand this change avoids spawning lots of probably useless threads, since most dependencies don't implement the worker lifecycle methods.

In practice I think the performance change will be negligible.