### PR TITLE
use pyamqp:// in all defaults and examples

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -58,7 +58,7 @@ Optionally you can provide default values ``${ENV_VAR:default_value}``
 .. code-block:: yaml
 
     # foobar.yaml
-    AMQP_URI: amqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}
+    AMQP_URI: pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}
 
 To run your service and set environment variables for it to use:
 
@@ -71,7 +71,7 @@ If you need to quote the values in your YAML file, the explicit ``!env_var`` res
 .. code-block:: yaml
 
     # foobar.yaml
-    AMQP_URI: !env_var "amqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}"
+    AMQP_URI: !env_var "pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}"
 
 Interacting with running services
 ---------------------------------

--- a/nameko/amqp.py
+++ b/nameko/amqp.py
@@ -43,7 +43,7 @@ class TestTransport(Transport):
 
 def verify_amqp_uri(amqp_uri):
     connection = Connection(amqp_uri)
-    if connection.transport_cls != 'amqp':
+    if connection.transport_cls not in ('amqp', 'pyamqp'):
         # Can't use these heuristics. Fall back to the existing error behaviour
         return
 

--- a/nameko/cli/commands.py
+++ b/nameko/cli/commands.py
@@ -68,7 +68,7 @@ class Run(Command):
             help='The YAML configuration file')
 
         parser.add_argument(
-            '--broker', default='amqp://guest:guest@localhost',
+            '--broker', default='pyamqp://guest:guest@localhost',
             help='RabbitMQ broker url')
 
         parser.add_argument(
@@ -101,7 +101,7 @@ class Shell(Command):
     @classmethod
     def init_parser(cls, parser):
         parser.add_argument(
-            '--broker', default='amqp://guest:guest@localhost',
+            '--broker', default='pyamqp://guest:guest@localhost',
             help='RabbitMQ broker url')
         parser.add_argument(
             '--interface', choices=cls.SHELLS,

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -24,7 +24,7 @@ def pytest_addoption(parser):
 
     parser.addoption(
         "--amqp-uri", action="store", dest='AMQP_URI',
-        default='amqp://guest:guest@localhost:5672/:random:',
+        default='pyamqp://guest:guest@localhost:5672/:random:',
         help=("The AMQP-URI to connect to rabbit with."))
 
     parser.addoption(

--- a/test/cli/config.yaml
+++ b/test/cli/config.yaml
@@ -3,5 +3,5 @@
 
 WEB_SERVER_ADDRESS: '0.0.0.0:8001'
 
-AMQP_URI: 'amqp://guest:guest@localhost'
+AMQP_URI: 'pyamqp://guest:guest@localhost'
 serializer: 'json'

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -62,7 +62,7 @@ def test_main_with_config(rabbit_config):
 
         assert config == {
             WEB_SERVER_CONFIG_KEY: '0.0.0.0:8001',
-            AMQP_URI_CONFIG_KEY: 'amqp://guest:guest@localhost',
+            AMQP_URI_CONFIG_KEY: 'pyamqp://guest:guest@localhost',
             SERIALIZER_CONFIG_KEY: 'json'
         }
 

--- a/test/cli/test_shell.py
+++ b/test/cli/test_shell.py
@@ -127,7 +127,7 @@ def test_config(pystartup):
     assert 'n' in local.keys()
     assert local['n'].config == {
         WEB_SERVER_CONFIG_KEY: '0.0.0.0:8001',
-        AMQP_URI_CONFIG_KEY: 'amqp://guest:guest@localhost',
+        AMQP_URI_CONFIG_KEY: 'pyamqp://guest:guest@localhost',
         SERIALIZER_CONFIG_KEY: 'json'
     }
     local['n'].disconnect()

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -47,7 +47,7 @@ def test_rabbit_config_specific_vhost(testdir):
         """
     )
     result = testdir.runpytest(
-        "--amqp-uri", "amqp://guest:guest@localhost:5672/specified_vhost"
+        "--amqp-uri", "pyamqp://guest:guest@localhost:5672/specified_vhost"
     )
     assert result.ret == 0
 


### PR DESCRIPTION
Avoids confusion like https://github.com/nameko/nameko/issues/403