### PR TITLE
standalone rpc: non blocking queue consumer

### DIFF
--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -207,14 +207,16 @@ class StandaloneProxyBase(object):
 
     def __init__(
         self, config, context_data=None, timeout=None,
-        worker_ctx_cls=WorkerContext, reply_listener_cls=SingleThreadedReplyListener
+        worker_ctx_cls=WorkerContext,
+        reply_listener_cls=SingleThreadedReplyListener
     ):
         container = self.ServiceContainer(config)
 
         self._worker_ctx = worker_ctx_cls(
             container, service=None, entrypoint=self.Dummy,
             data=context_data)
-        self._reply_listener = reply_listener_cls(timeout=timeout).bind(container)
+        self._reply_listener = reply_listener_cls(
+            timeout=timeout).bind(container)
 
     def __enter__(self):
         return self.start()

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -11,7 +11,7 @@ from nameko.containers import WorkerContext
 from nameko.exceptions import RemoteError, RpcConnectionError, RpcTimeout
 from nameko.extensions import DependencyProvider
 from nameko.rpc import MethodProxy, Responder, rpc
-from nameko.standalone.rpc import ClusterRpcProxy, ServiceRpcProxy, MultiClusterRpcProxy
+from nameko.standalone.rpc import ClusterRpcProxy, ServiceRpcProxy, MultiReplyListener
 from nameko.testing.utils import get_rabbit_connections
 from nameko.testing.waiting import wait_for_call as patch_wait
 
@@ -363,7 +363,7 @@ def test_multi_cluster_proxy(container_factory, rabbit_manager, rabbit_config):
     container = container_factory(FooService, rabbit_config)
     container.start()
 
-    with MultiClusterRpcProxy(rabbit_config) as proxy:
+    with ClusterRpcProxy(rabbit_config, reply_listener_cls=MultiReplyListener) as proxy:
         assert proxy.foobar.spam(ham=1) == 1
 
 
@@ -371,7 +371,7 @@ def test_multi_cluster_proxy_dict_access(container_factory, rabbit_manager, rabb
     container = container_factory(FooService, rabbit_config)
     container.start()
 
-    with MultiClusterRpcProxy(rabbit_config) as proxy:
+    with ClusterRpcProxy(rabbit_config, reply_listener_cls=MultiReplyListener) as proxy:
         assert proxy['foobar'].spam(ham=3) == 3
 
 
@@ -380,7 +380,7 @@ def test_async_multi_cluster_proxy(container_factory, rabbit_config):
     container = container_factory(FooService, rabbit_config)
     container.start()
 
-    with MultiClusterRpcProxy(rabbit_config) as proxy:
+    with ClusterRpcProxy(rabbit_config, reply_listener_cls=MultiReplyListener) as proxy:
         rep1 = proxy.foobar.spam.call_async(ham=1)
         rep2 = proxy.foobar.spam.call_async(ham=2)
         rep3 = proxy.foobar.spam.call_async(ham=3)

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -11,7 +11,7 @@ from nameko.containers import WorkerContext
 from nameko.exceptions import RemoteError, RpcConnectionError, RpcTimeout
 from nameko.extensions import DependencyProvider
 from nameko.rpc import MethodProxy, Responder, rpc
-from nameko.standalone.rpc import ClusterRpcProxy, ServiceRpcProxy, MultiReplyListener
+from nameko.standalone.rpc import ClusterRpcProxy, ServiceRpcProxy
 from nameko.testing.utils import get_rabbit_connections
 from nameko.testing.waiting import wait_for_call as patch_wait
 
@@ -357,40 +357,6 @@ def test_cluster_proxy_dict_access(
 
     with ClusterRpcProxy(rabbit_config) as proxy:
         assert proxy['foobar'].spam(ham=3) == 3
-
-
-def test_multi_cluster_proxy(container_factory, rabbit_manager, rabbit_config):
-    container = container_factory(FooService, rabbit_config)
-    container.start()
-
-    with ClusterRpcProxy(rabbit_config, reply_listener_cls=MultiReplyListener) as proxy:
-        assert proxy.foobar.spam(ham=1) == 1
-
-
-def test_multi_cluster_proxy_dict_access(container_factory, rabbit_manager, rabbit_config):
-    container = container_factory(FooService, rabbit_config)
-    container.start()
-
-    with ClusterRpcProxy(rabbit_config, reply_listener_cls=MultiReplyListener) as proxy:
-        assert proxy['foobar'].spam(ham=3) == 3
-
-
-def test_async_multi_cluster_proxy(container_factory, rabbit_config):
-
-    container = container_factory(FooService, rabbit_config)
-    container.start()
-
-    with ClusterRpcProxy(rabbit_config, reply_listener_cls=MultiReplyListener) as proxy:
-        rep1 = proxy.foobar.spam.call_async(ham=1)
-        rep2 = proxy.foobar.spam.call_async(ham=2)
-        rep3 = proxy.foobar.spam.call_async(ham=3)
-        rep4 = proxy.foobar.spam.call_async(ham=4)
-        rep5 = proxy.foobar.spam.call_async(ham=5)
-        assert rep2.result() == 2
-        assert rep3.result() == 3
-        assert rep1.result() == 1
-        assert rep4.result() == 4
-        assert rep5.result() == 5
 
 
 def test_recover_from_keyboardinterrupt(

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -11,7 +11,7 @@ from nameko.containers import WorkerContext
 from nameko.exceptions import RemoteError, RpcConnectionError, RpcTimeout
 from nameko.extensions import DependencyProvider
 from nameko.rpc import MethodProxy, Responder, rpc
-from nameko.standalone.rpc import ClusterRpcProxy, ServiceRpcProxy
+from nameko.standalone.rpc import ClusterRpcProxy, ServiceRpcProxy, MultiClusterRpcProxy
 from nameko.testing.utils import get_rabbit_connections
 from nameko.testing.waiting import wait_for_call as patch_wait
 
@@ -357,6 +357,40 @@ def test_cluster_proxy_dict_access(
 
     with ClusterRpcProxy(rabbit_config) as proxy:
         assert proxy['foobar'].spam(ham=3) == 3
+
+
+def test_multi_cluster_proxy(container_factory, rabbit_manager, rabbit_config):
+    container = container_factory(FooService, rabbit_config)
+    container.start()
+
+    with MultiClusterRpcProxy(rabbit_config) as proxy:
+        assert proxy.foobar.spam(ham=1) == 1
+
+
+def test_multi_cluster_proxy_dict_access(container_factory, rabbit_manager, rabbit_config):
+    container = container_factory(FooService, rabbit_config)
+    container.start()
+
+    with MultiClusterRpcProxy(rabbit_config) as proxy:
+        assert proxy['foobar'].spam(ham=3) == 3
+
+
+def test_async_multi_cluster_proxy(container_factory, rabbit_config):
+
+    container = container_factory(FooService, rabbit_config)
+    container.start()
+
+    with MultiClusterRpcProxy(rabbit_config) as proxy:
+        rep1 = proxy.foobar.spam.call_async(ham=1)
+        rep2 = proxy.foobar.spam.call_async(ham=2)
+        rep3 = proxy.foobar.spam.call_async(ham=3)
+        rep4 = proxy.foobar.spam.call_async(ham=4)
+        rep5 = proxy.foobar.spam.call_async(ham=5)
+        assert rep2.result() == 2
+        assert rep3.result() == 3
+        assert rep1.result() == 1
+        assert rep4.result() == 4
+        assert rep5.result() == 5
 
 
 def test_recover_from_keyboardinterrupt(


### PR DESCRIPTION
Following up on the [discussion](https://groups.google.com/forum/#!topic/nameko-dev/hGpYx7ka1lI), I prepare change with non-blocking standalone rpc queue consumer. It should help communicate other software with nameko (like: flask) and dealing with connections. 

**Why I need that?** : I want use flask generated REST API with swagger codegen. Flask should provide API gateway to access to microservices on nameko. Flask provide better tools set for REST API creation.

**How it use?** : MultiReplyListener provide non-blocking wait for replies from rabbitmq (like: ReplyListener)
```
from nameko.standalone.rpc import ClusterRpcProxy, MultiReplyListener

with ClusterRpcProxy(rabbit_config, reply_listener_cls=MultiReplyListener) as proxy:
    proxy.foobar.spam()
```

Thanks for the any feedback!