### PR TITLE
Fixes for testing against non-local rabbit; and always using clean vhost

### DIFF
--- a/docs/examples/config_dependency_provider.py
+++ b/docs/examples/config_dependency_provider.py
@@ -1,9 +1,5 @@
 from nameko.dependency_providers import Config
-from nameko.rpc import rpc
-
-
-class FeatureNotEnabled(Exception):
-    pass
+from nameko.web.handlers import http
 
 
 class Service:
@@ -16,9 +12,9 @@ class Service:
     def foo_enabled(self):
         return self.config.get('FOO_FEATURE_ENABLED', False)
 
-    @rpc
-    def foo(self):
+    @http('GET', '/foo')
+    def foo(self, request):
         if not self.foo_enabled:
-            raise FeatureNotEnabled()
+            return 403, "FeatureNotEnabled"
 
         return 'foo'

--- a/docs/examples/test/test_examples.py
+++ b/docs/examples/test/test_examples.py
@@ -286,22 +286,22 @@ class TestWebsocketRpc(object):
 
 class TestConfig:
 
-    def test_config_value_not_set(self, container_factory, empty_config):
+    def test_config_value_not_set(self, container_factory, rabbit_config):
         from examples.config_dependency_provider import (
             Service, FeatureNotEnabled
         )
 
-        container = container_factory(Service, empty_config)
+        container = container_factory(Service, rabbit_config)
         container.start()
 
         with pytest.raises(FeatureNotEnabled):
             with entrypoint_hook(container, "foo") as foo:
                 foo()
 
-    def test_can_get_config_value(self, container_factory, empty_config):
+    def test_can_get_config_value(self, container_factory, rabbit_config):
         from examples.config_dependency_provider import Service
 
-        config = empty_config.copy()
+        config = rabbit_config
         config["FOO_FEATURE_ENABLED"] = True
 
         container = container_factory(Service, config)
@@ -309,4 +309,3 @@ class TestConfig:
 
         with entrypoint_hook(container, "foo") as foo:
             assert foo() == "foo"
-

--- a/docs/examples/test/test_examples.py
+++ b/docs/examples/test/test_examples.py
@@ -2,7 +2,6 @@
 """ Tests for the files and snippets in nameko/docs/examples
 """
 import os
-import pytest
 
 from mock import call, patch
 
@@ -286,26 +285,29 @@ class TestWebsocketRpc(object):
 
 class TestConfig:
 
-    def test_config_value_not_set(self, container_factory, rabbit_config):
-        from examples.config_dependency_provider import (
-            Service, FeatureNotEnabled
-        )
-
-        container = container_factory(Service, rabbit_config)
-        container.start()
-
-        with pytest.raises(FeatureNotEnabled):
-            with entrypoint_hook(container, "foo") as foo:
-                foo()
-
-    def test_can_get_config_value(self, container_factory, rabbit_config):
+    def test_config_value_not_set(
+        self, container_factory, web_config, web_session
+    ):
         from examples.config_dependency_provider import Service
 
-        config = rabbit_config
+        container = container_factory(Service, web_config)
+        container.start()
+
+        res = web_session.get('/foo')
+        assert res.status_code == 403
+        assert res.text == "FeatureNotEnabled"
+
+    def test_can_get_config_value(
+        self, container_factory, web_config, web_session
+    ):
+        from examples.config_dependency_provider import Service
+
+        config = web_config
         config["FOO_FEATURE_ENABLED"] = True
 
         container = container_factory(Service, config)
         container.start()
 
-        with entrypoint_hook(container, "foo") as foo:
-            assert foo() == "foo"
+        res = web_session.get('/foo')
+        assert res.status_code == 200
+        assert res.text == "foo"

--- a/nameko/amqp.py
+++ b/nameko/amqp.py
@@ -43,7 +43,7 @@ class TestTransport(Transport):
 
 def verify_amqp_uri(amqp_uri):
     connection = Connection(amqp_uri)
-    if connection.transport_cls != 'amqp':
+    if connection.transport_cls not in ('amqp', 'pyamqp'):
         # Can't use these heuristics. Fall back to the existing error behaviour
         return
 

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -23,29 +23,22 @@ def pytest_addoption(parser):
         help=("The logging-level for the test run."))
 
     parser.addoption(
-        "--rabbit-host", action="store", dest='RABBIT_HOST',
-        default='localhost',
-        help=("Hostname of the RabbitMQ broker."))
+        "--amqp-uri", "--rabbit-amqp-uri",
+        action="store",
+        dest='RABBIT_AMQP_URI',
+        default='pyamqp://guest:guest@localhost:5672/',
+        help=(
+            "URI for the RabbitMQ broker. Any specified virtual host will be "
+            "ignored because tests run in their own isolated vhost."
+        ))
 
     parser.addoption(
-        "--rabbit-port", action="store", dest='RABBIT_PORT',
-        default='5672',
-        help=("AMQP port number on RabbitMQ broker."))
-
-    parser.addoption(
-        "--rabbit-user", action="store", dest='RABBIT_USER',
-        default='guest',
-        help=("RabbitMQ username."))
-
-    parser.addoption(
-        "--rabbit-pass", action="store", dest='RABBIT_PASS',
-        default='guest',
-        help=("RabbitMQ password."))
-
-    parser.addoption(
-        "--rabbit-api-uri", action="store", dest='RABBIT_API_URI',
+        "--rabbit-api-uri", "--rabbit-ctl-uri",
+        action="store",
+        dest='RABBIT_API_URI',
         default='http://guest:guest@localhost:15672',
-        help=("URI for RabbitMQ management interface."))
+        help=("URI for RabbitMQ management interface.")
+    )
 
 
 def pytest_load_initial_conftests():
@@ -108,21 +101,22 @@ def rabbit_config(request, rabbit_manager):
     import string
     import time
     from kombu import pools
+    from six.moves.urllib.parse import urlparse
     from nameko.testing.utils import get_rabbit_connections
 
-    host = request.config.getoption('RABBIT_HOST')
-    port = request.config.getoption('RABBIT_PORT')
-    username = request.config.getoption('RABBIT_USER')
-    password = request.config.getoption('RABBIT_PASS')
+    rabbit_amqp_uri = request.config.getoption('RABBIT_AMQP_URI')
+    uri_parts = urlparse(rabbit_amqp_uri)
+    username = uri_parts.username
 
     vhost = "nameko_test_{}".format(
         "".join(random.choice(string.ascii_lowercase) for _ in range(10))
     )
-    amqp_uri = "pyamqp://{}:{}@{}:{}/{}".format(
-        username, password, host, port, vhost
-    )
     rabbit_manager.create_vhost(vhost)
     rabbit_manager.set_vhost_permissions(vhost, username, '.*', '.*', '.*')
+
+    amqp_uri = "{uri.scheme}://{uri.netloc}/{vhost}".format(
+        uri=uri_parts, vhost=vhost
+    )
 
     conf = {
         'AMQP_URI': amqp_uri,

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -43,7 +43,7 @@ def pytest_addoption(parser):
         help=("RabbitMQ password."))
 
     parser.addoption(
-        "--rabbit-mgmt-uri", action="store", dest='RABBIT_MGMT_URI',
+        "--rabbit-api-uri", action="store", dest='RABBIT_API_URI',
         default='http://guest:guest@localhost:15672',
         help=("URI for RabbitMQ management interface."))
 
@@ -98,7 +98,7 @@ def rabbit_manager(request):
     from nameko.testing import rabbit
 
     config = request.config
-    return rabbit.Client(config.getoption('RABBIT_MGMT_URI'))
+    return rabbit.Client(config.getoption('RABBIT_API_URI'))
 
 
 @pytest.yield_fixture()

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -61,10 +61,7 @@ def always_warn_for_deprecation():
 
 @pytest.fixture
 def empty_config():
-    from nameko.constants import AMQP_URI_CONFIG_KEY
-    return {
-        AMQP_URI_CONFIG_KEY: ""
-    }
+    return {}
 
 
 @pytest.fixture

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -101,7 +101,7 @@ def rabbit_config(request, rabbit_manager):
     import string
     import time
     from kombu import pools
-    from six.moves.urllib.parse import urlparse
+    from six.moves.urllib.parse import urlparse  # pylint: disable=E0401
     from nameko.testing.utils import get_rabbit_connections
 
     rabbit_amqp_uri = request.config.getoption('RABBIT_AMQP_URI')

--- a/test/cli/config.yaml
+++ b/test/cli/config.yaml
@@ -1,7 +1,0 @@
-# nameko config file for testing
-# $> nameko run --config run-config.yaml foobar
-
-WEB_SERVER_ADDRESS: '0.0.0.0:8001'
-
-AMQP_URI: 'amqp://guest:guest@localhost'
-serializer: 'json'

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -46,12 +46,20 @@ def test_run(rabbit_config):
     gt.wait()
 
 
-def test_main_with_config(rabbit_config):
+def test_main_with_config(rabbit_config, tmpdir):
+
+    config = tmpdir.join('config.yaml')
+    config.write("""
+        WEB_SERVER_ADDRESS: '0.0.0.0:8001'
+        AMQP_URI: '{}'
+        serializer: 'json'
+    """.format(rabbit_config[AMQP_URI_CONFIG_KEY]))
+
     parser = setup_parser()
     args = parser.parse_args([
         'run',
         '--config',
-        TEST_CONFIG_FILE,
+        config.strpath,
         'test.sample',
     ])
 
@@ -62,7 +70,7 @@ def test_main_with_config(rabbit_config):
 
         assert config == {
             WEB_SERVER_CONFIG_KEY: '0.0.0.0:8001',
-            AMQP_URI_CONFIG_KEY: 'amqp://guest:guest@localhost',
+            AMQP_URI_CONFIG_KEY: rabbit_config[AMQP_URI_CONFIG_KEY],
             SERIALIZER_CONFIG_KEY: 'json'
         }
 

--- a/test/test_dependency_providers.py
+++ b/test/test_dependency_providers.py
@@ -19,9 +19,9 @@ class TestConfig:
         return Service
 
     def test_get_config_value(
-        self, empty_config, container_factory, service_cls
+        self, rabbit_config, container_factory, service_cls
     ):
-        config = empty_config.copy()
+        config = rabbit_config
         config["FOO"] = "bar"
 
         container = container_factory(service_cls, config)

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -27,9 +27,10 @@ def queue_consumer():
         yield replacement
 
 
-def test_event_dispatcher(mock_container, mock_producer):
+def test_event_dispatcher(mock_container, mock_producer, rabbit_config):
 
     container = mock_container
+    container.config = rabbit_config
     container.service_name = "srcservice"
 
     service = Mock()

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -103,9 +103,11 @@ def test_consume_provider(mock_container):
 
 @pytest.mark.usefixtures("predictable_call_ids")
 def test_publish_to_exchange(
-    maybe_declare, mock_connection, mock_producer, mock_container
+    maybe_declare, mock_connection, mock_producer, mock_container,
+    rabbit_config
 ):
     container = mock_container
+    container.config = rabbit_config
     container.service_name = "srcservice"
 
     service = Mock()
@@ -132,9 +134,11 @@ def test_publish_to_exchange(
 
 @pytest.mark.usefixtures("predictable_call_ids")
 def test_publish_to_queue(
-    maybe_declare, mock_producer, mock_connection, mock_container
+    maybe_declare, mock_producer, mock_connection, mock_container,
+    rabbit_config
 ):
     container = mock_container
+    container.config = rabbit_config
     container.shared_extensions = {}
     container.service_name = "srcservice"
 
@@ -165,10 +169,12 @@ def test_publish_to_queue(
 
 @pytest.mark.usefixtures("predictable_call_ids")
 def test_publish_custom_headers(
-    mock_container, maybe_declare, mock_producer, mock_connection
+    mock_container, maybe_declare, mock_producer, mock_connection,
+    rabbit_config
 ):
 
     container = mock_container
+    container.config = rabbit_config
     container.service_name = "srcservice"
 
     ctx_data = {'language': 'en', 'customheader': 'customvalue'}

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -25,7 +25,7 @@ def plugin_options(request):
         '--rabbit-port',
         '--rabbit-user',
         '--rabbit-pass',
-        '--rabbit-mgmt-uri'
+        '--rabbit-api-uri'
     )
 
     args = [

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -21,10 +21,7 @@ def plugin_options(request):
     them into subprocess pytests created by the pytester plugin.
     """
     options = (
-        '--rabbit-host',
-        '--rabbit-port',
-        '--rabbit-user',
-        '--rabbit-pass',
+        '--rabbit-amqp-uri',
         '--rabbit-api-uri'
     )
 

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -16,7 +16,7 @@ pytest_plugins = "pytester"
 
 
 def test_empty_config(empty_config):
-    assert AMQP_URI_CONFIG_KEY in empty_config
+    assert empty_config == {}
 
 
 def test_rabbit_manager(rabbit_manager):

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -2,7 +2,7 @@ import socket
 
 import pytest
 
-from nameko.constants import AMQP_URI_CONFIG_KEY, WEB_SERVER_CONFIG_KEY
+from nameko.constants import WEB_SERVER_CONFIG_KEY
 from nameko.extensions import DependencyProvider
 from nameko.rpc import RpcProxy, rpc
 from nameko.standalone.rpc import ServiceRpcProxy


### PR DESCRIPTION
It turns out that we had quite a few tests that assume RabbitMQ is running on localhost and port 5672. This PR fixes those tests (although it doesn't update the Travis config to prove it).

It also turns out that many test assume they're running against a clean vhost and fail otherwise. Accordingly I have removed the `:random:` vhost option and always create a fresh one. Since the vhost is part of a normal URI I've replaced this pytest option into four new options that allow the other parts of the URI to be overridden: host, port, username and password.

