### PR TITLE
Faster teardown

### DIFF
--- a/docs/examples/test/test_examples.py
+++ b/docs/examples/test/test_examples.py
@@ -286,22 +286,22 @@ class TestWebsocketRpc(object):
 
 class TestConfig:
 
-    def test_config_value_not_set(self, container_factory, empty_config):
+    def test_config_value_not_set(self, container_factory, rabbit_config):
         from examples.config_dependency_provider import (
             Service, FeatureNotEnabled
         )
 
-        container = container_factory(Service, empty_config)
+        container = container_factory(Service, rabbit_config)
         container.start()
 
         with pytest.raises(FeatureNotEnabled):
             with entrypoint_hook(container, "foo") as foo:
                 foo()
 
-    def test_can_get_config_value(self, container_factory, empty_config):
+    def test_can_get_config_value(self, container_factory, rabbit_config):
         from examples.config_dependency_provider import Service
 
-        config = empty_config.copy()
+        config = rabbit_config
         config["FOO_FEATURE_ENABLED"] = True
 
         container = container_factory(Service, config)
@@ -309,4 +309,3 @@ class TestConfig:
 
         with entrypoint_hook(container, "foo") as foo:
             assert foo() == "foo"
-

--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -3,10 +3,8 @@ Provides core messaging decorators and dependency providers.
 '''
 from __future__ import absolute_import
 
-import socket
 import warnings
 from functools import partial
-from itertools import count
 from logging import getLogger
 
 import eventlet
@@ -386,7 +384,7 @@ class QueueConsumer(SharedExtension, ProviderCollector, ConsumerMixin):
         )
         return Connection(self.amqp_uri, heartbeat=heartbeat)
 
-    def get_consumers(self, Consumer, channel):
+    def get_consumers(self, consumer_cls, channel):
         """ Kombu callback to set up consumers.
 
         Called after any (re)connection to the broker.
@@ -396,8 +394,11 @@ class QueueConsumer(SharedExtension, ProviderCollector, ConsumerMixin):
         for provider in self._providers:
             callbacks = [self._on_message, provider.handle_message]
 
-            consumer = Consumer(queues=[provider.queue], callbacks=callbacks,
-                                accept=self.accept)
+            consumer = consumer_cls(
+                queues=[provider.queue],
+                callbacks=callbacks,
+                accept=self.accept
+            )
             consumer.qos(prefetch_count=self.prefetch_count)
 
             self._consumers[provider] = consumer

--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -439,35 +439,6 @@ class QueueConsumer(SharedExtension, ProviderCollector, ConsumerMixin):
             else:
                 callback()
 
-    def consume(self, limit=None, timeout=None, safety_interval=1, **kwargs):
-        """ Lifted from kombu
-
-        We switch the order of the `break` and `self.on_iteration()` to
-        avoid waiting on a drain_events timeout before breaking the loop.
-        """
-        elapsed = 0
-        with self.consumer_context(**kwargs) as (conn, channel, consumers):
-            for i in limit and range(limit) or count():
-                self.on_iteration()
-                if self.should_stop:
-                    break
-                try:
-                    conn.drain_events(timeout=safety_interval)
-                except socket.timeout:
-                    conn.heartbeat_check()
-                    elapsed += safety_interval
-                    if timeout and elapsed >= timeout:
-                        # Excluding the following clause from coverage,
-                        # as timeout never appears to be set - This method
-                        # is a lift from kombu so will leave in place for now.
-                        raise  # pragma: no cover
-                except socket.error:
-                    if not self.should_stop:
-                        raise
-                else:
-                    yield
-                    elapsed = 0
-
 
 class Consumer(Entrypoint, HeaderDecoder):
 

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -102,16 +102,7 @@ def rabbit_manager(request):
 
 
 @pytest.yield_fixture()
-def rabbit_config(request, rabbit_manager, container_factory, runner_factory):
-    """
-    Having this fixture depend on `container_factory` and `runner_factory`
-    ensures that those fixtures tear down after this one.
-
-    By chance, this considerably speeds up tests that use those fixtures.
-    The reason is that deleting the RabbitMQ vhost sends basic-cancel to any
-    consumers, triggering the ConsumerMixin to perform its iteration cycle
-    early rather than waiting for the timeout to fire on its socket read.
-    """
+def rabbit_config(request, rabbit_manager):
     import random
     import string
 
@@ -139,6 +130,80 @@ def rabbit_config(request, rabbit_manager, container_factory, runner_factory):
     rabbit_manager.delete_vhost(vhost)
 
 
+@pytest.yield_fixture(autouse=True)
+def fast_teardown(container_factory, runner_factory, rabbit_config):
+    """
+    This fixture fixes the order of the `container_factory`, `runner_factory`
+    and `rabbit_config` fixtures to get the fastest possible teardown of tests
+    that use them.
+
+    Without this fixture, the teardown order depends on the fixture resolution
+    defined by the test, for example::
+
+    def test_foo(container_factory, rabbit_config):
+        pass  # rabbit_config tears down first
+
+    def test_bar(rabbit_config, container_factory):
+        pass  # container_factory tears down first
+
+    This fixture ensures the teardown order is:
+
+        1. `fast_teardown`  (this fixture)
+        2. `rabbit_config`
+        3. `container_factory` / `runner_factory`
+
+    That is, `rabbit_config` teardown, which removes the vhost created for
+    the test, happens *before* the consumers are stopped.
+
+    Deleting the vhost causes the broker to sends a "basic-cancel" message
+    to any connected consumers, which will include the consumers in all
+    containers created by the `container_factory` and `runner_factory`
+    fixtures.
+
+    This speeds up test teardown because the "basic-cancel" breaks
+    the consumers' `drain_events` loop (http://bit.do/kombu-drain-events)
+    which would otherwise wait for up to a second for the socket read to time
+    out before gracefully shutting down.
+
+    For even faster teardown, we monkeypatch the consumers to ensure they
+    don't try to reconnect between the "basic-cancel" and being explicitly
+    stopped when their container is killed.
+
+    In older versions of RabbitMQ, the monkeypatch also protects against a
+    race-condition that can lead to hanging tests.
+
+    Modern RabbitMQ raises a `NotAllowed` exception if you try to connect to
+    a vhost that doesn't exist, but older versions (including 3.4.3, used by
+    Travis) just raise a `socket.error`. This is classed as a recoverable
+    error, and consumers attempt to reconnect. Kombu's reconnection code blocks
+    until a connection is established, so consumers that attempt to reconnect
+    before being killed get stuck there.
+    """
+
+    from kombu.mixins import ConsumerMixin
+
+    consumers = []
+
+    # monkeypatch the ConsumerMixin constructor to stash a reference to
+    # each instance
+    orig_init = ConsumerMixin.__init__
+
+    def __init__(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        consumers.append(self)
+
+    ConsumerMixin.__init__ = __init__
+
+    yield
+    ConsumerMixin.__init__ = orig_init
+
+    # set the `should_stop` attribute on all consumers *before* the rabbit
+    # vhost is killed, so that they don't try to reconnect before they're
+    # explicitly killed when their container stops.
+    for consumer in consumers:
+        consumer.should_stop = True
+
+
 @pytest.yield_fixture
 def container_factory():
     from nameko.containers import get_container_cls
@@ -162,7 +227,6 @@ def container_factory():
         return container
 
     yield make_container
-
     for c in all_containers:
         try:
             c.kill()

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -130,17 +130,8 @@ def rabbit_config(request, rabbit_manager):
     rabbit_manager.delete_vhost(vhost)
 
 
-@pytest.fixture
-def ensure_cleanup_order(request):
-    """ Ensure ``rabbit_config`` is invoked early if it's used by any fixture
-    in ``request``.
-    """
-    if "rabbit_config" in request.funcargnames:
-        request.getfuncargvalue("rabbit_config")
-
-
 @pytest.yield_fixture
-def container_factory(ensure_cleanup_order):
+def container_factory():
     from nameko.containers import get_container_cls
     import warnings
 

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -43,7 +43,7 @@ def pytest_addoption(parser):
         help=("RabbitMQ password."))
 
     parser.addoption(
-        "--rabbit-mgmt-uri", action="store", dest='RABBIT_MGMT_URI',
+        "--rabbit-api-uri", action="store", dest='RABBIT_API_URI',
         default='http://guest:guest@localhost:15672',
         help=("URI for RabbitMQ management interface."))
 
@@ -98,7 +98,7 @@ def rabbit_manager(request):
     from nameko.testing import rabbit
 
     config = request.config
-    return rabbit.Client(config.getoption('RABBIT_MGMT_URI'))
+    return rabbit.Client(config.getoption('RABBIT_API_URI'))
 
 
 @pytest.yield_fixture()

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -102,7 +102,16 @@ def rabbit_manager(request):
 
 
 @pytest.yield_fixture()
-def rabbit_config(request, rabbit_manager):
+def rabbit_config(request, rabbit_manager, container_factory, runner_factory):
+    """
+    Having this fixture depend on `container_factory` and `runner_factory`
+    ensures that those fixtures tear down after this one.
+
+    By chance, this considerably speeds up tests that use those fixtures.
+    The reason is that deleting the RabbitMQ vhost sends basic-cancel to any
+    consumers, triggering the ConsumerMixin to perform its iteration cycle
+    early rather than waiting for the timeout to fire on its socket read.
+    """
     import random
     import string
 
@@ -162,7 +171,7 @@ def container_factory():
 
 
 @pytest.yield_fixture
-def runner_factory(ensure_cleanup_order):
+def runner_factory():
     from nameko.runners import ServiceRunner
 
     all_runners = []

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -98,7 +98,7 @@ def rabbit_manager(request):
 def rabbit_config(request, rabbit_manager):
     import random
     import string
-    from six.moves.urllib.parse import urlparse
+    from six.moves.urllib.parse import urlparse  # pylint: disable=E0401
 
     rabbit_amqp_uri = request.config.getoption('RABBIT_AMQP_URI')
     uri_parts = urlparse(rabbit_amqp_uri)

--- a/test/test_service_runner.py
+++ b/test/test_service_runner.py
@@ -364,7 +364,7 @@ def test_runner_with_duplicate_services(
 
     # it should only be hosted once
     assert len(runner.containers) == 1
-    container = runner.containers[0]
+    container = list(runner.containers)[0]
 
     # test events (only one service is hosted)
     event_data = "event"

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -25,7 +25,7 @@ def plugin_options(request):
         '--rabbit-port',
         '--rabbit-user',
         '--rabbit-pass',
-        '--rabbit-mgmt-uri'
+        '--rabbit-api-uri'
     )
 
     args = [

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -43,37 +43,6 @@ def test_rabbit_manager(rabbit_manager):
     assert "/" in [vhost['name'] for vhost in rabbit_manager.get_all_vhosts()]
 
 
-def test_rabbit_config_leftover_connections(testdir, plugin_options):
-
-    # run a test that leaves connections lying around
-    testdir.makepyfile(
-        """
-        from nameko.containers import ServiceContainer
-        from nameko.rpc import rpc
-
-        class Service(object):
-            name = "service"
-
-            @rpc
-            def method(self):
-                pass
-
-        def test_rabbit_config(rabbit_config):
-
-            # not using container factory; will leave connections behind
-            container = ServiceContainer(Service, rabbit_config)
-            container.start()
-        """
-    )
-
-    result = testdir.runpytest(*plugin_options)
-
-    assert result.ret == 1
-    result.stdout.fnmatch_lines(
-        ["*RuntimeError: 1 rabbit connection(s) left open*"]
-    )
-
-
 def test_cleanup_order(testdir, plugin_options):
 
     # without ``ensure_cleanup_order``, the following fixture ordering would

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -21,10 +21,7 @@ def plugin_options(request):
     them into subprocess pytests created by the pytester plugin.
     """
     options = (
-        '--rabbit-host',
-        '--rabbit-port',
-        '--rabbit-user',
-        '--rabbit-pass',
+        '--rabbit-amqp-uri',
         '--rabbit-api-uri'
     )
 

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -43,31 +43,6 @@ def test_rabbit_manager(rabbit_manager):
     assert "/" in [vhost['name'] for vhost in rabbit_manager.get_all_vhosts()]
 
 
-def test_cleanup_order(testdir, plugin_options):
-
-    # without ``ensure_cleanup_order``, the following fixture ordering would
-    # tear down ``rabbit_config`` before the ``container_factory`` (generating
-    # an error about rabbit connections being left open)
-    testdir.makepyfile(
-        """
-        from nameko.rpc import rpc
-
-        class Service(object):
-            name = "service"
-
-            @rpc
-            def method(self):
-                pass
-
-        def test_service(container_factory, rabbit_config):
-            container = container_factory(Service, rabbit_config)
-            container.start()
-        """
-    )
-    result = testdir.runpytest(*plugin_options)
-    assert result.ret == 0
-
-
 def test_container_factory(
     testdir, rabbit_config, rabbit_manager, plugin_options
 ):

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -40,6 +40,147 @@ def test_rabbit_manager(rabbit_manager):
     assert "/" in [vhost['name'] for vhost in rabbit_manager.get_all_vhosts()]
 
 
+class TestFastTeardown(object):
+
+    def test_order(self, testdir):
+
+        testdir.makeconftest(
+            """
+            from mock import Mock
+            import pytest
+
+            @pytest.fixture(scope='session')
+            def tracker():
+                return Mock()
+
+            @pytest.yield_fixture
+            def rabbit_config(tracker):
+                tracker("rabbit_config", "up")
+                yield
+                tracker("rabbit_config", "down")
+
+            @pytest.yield_fixture
+            def container_factory(tracker):
+                tracker("container_factory", "up")
+                yield
+                tracker("container_factory", "down")
+            """
+        )
+
+        testdir.makepyfile(
+            """
+            from mock import call
+
+            def test_foo(container_factory, rabbit_config):
+                pass  # factory first
+
+            def test_bar(rabbit_config, container_factory):
+                pass  # rabbit first
+
+            def test_check(tracker):
+                assert tracker.call_args_list == [
+                    # test_foo
+                    call("container_factory", "up"),
+                    call("rabbit_config", "up"),
+                    call("rabbit_config", "down"),
+                    call("container_factory", "down"),
+                    # test_bar
+                    call("container_factory", "up"),
+                    call("rabbit_config", "up"),
+                    call("rabbit_config", "down"),
+                    call("container_factory", "down"),
+                ]
+            """
+        )
+        result = testdir.runpytest()
+        assert result.ret == 0
+
+    def test_only_affects_used_fixtures(self, testdir):
+
+        testdir.makeconftest(
+            """
+            from mock import Mock
+            import pytest
+
+            @pytest.fixture(scope='session')
+            def tracker():
+                return Mock()
+
+            @pytest.yield_fixture
+            def rabbit_config(tracker):
+                tracker("rabbit_config", "up")
+                yield
+                tracker("rabbit_config", "down")
+
+            @pytest.yield_fixture
+            def container_factory(tracker):
+                tracker("container_factory", "up")
+                yield
+                tracker("container_factory", "down")
+            """
+        )
+
+        testdir.makepyfile(
+            """
+            from mock import call
+
+            def test_no_rabbit(container_factory):
+                pass  # factory first
+
+            def test_check(tracker):
+                assert tracker.call_args_list == [
+                    call("container_factory", "up"),
+                    call("container_factory", "down"),
+                ]
+            """
+        )
+        result = testdir.runpytest()
+        assert result.ret == 0
+
+    def test_consumer_mixin_patch(self, testdir):
+
+        testdir.makeconftest(
+            """
+            from kombu.mixins import ConsumerMixin
+            import pytest
+
+            consumers = []
+
+            @pytest.fixture(autouse=True)
+            def fast_teardown(patch_checker, fast_teardown):
+                ''' Shadow the fast_teardown fixture to set fixture order:
+
+                Setup:
+
+                    1. patch_checker
+                    2. original fast_teardown (applies monkeypatch)
+                    3. this fixture (creates consumer)
+
+                Teardown:
+
+                    1. this fixture (creates consumer)
+                    2. original fast_teardown (removes patch; sets attribute)
+                    3. patch_checker (verifies consumer was stopped)
+                '''
+                consumers.append(ConsumerMixin())
+
+            @pytest.yield_fixture
+            def patch_checker():
+                yield
+                assert consumers[0].should_stop is True
+            """
+        )
+
+        testdir.makepyfile(
+            """
+            def test_mixin_patch(patch_checker):
+                pass
+            """
+        )
+        result = testdir.runpytest()
+        assert result.ret == 0
+
+
 def test_container_factory(
     testdir, rabbit_config, rabbit_manager, plugin_options
 ):


### PR DESCRIPTION
Significantly speeds up test teardown by:

* Removing the leftover connection check (9371f2b) which is not useful when every test runs in its own vhost (it was added to prevent state lying around which may cause flakiness in later tests)
* Forcing the RabbitMQ fixture to stop _before_ stopping containers (3610e39), which breaks the consume loop early and lets us clean up sooner (see fixture docstring).

This change also allows to remove the kombu method override (2fea493) which was made to speed up teardown of the QueueConsumer. We now force this loop to exit early (during tests) so it doesn't matter whether `on_iteration` happens before or after the socket read.

As quick benchmark I ran the following test:

``` python
@pytest.mark.parametrize("iter", range(50))
def test_speedup(iter, rabbit_config, container_factory):

    class Service(object):
        name = "serv"

        @rpc
        def service(self):
            pass

    # do nothing except start and kill a container that connects to rabbit
    container = container_factory(Service, rabbit_config)
    container.start()
```

Results:
```
# master
50 passed in 87.97 seconds

# faster-teardown
50 passed in 36.62 seconds
```