### PR TITLE
use more explicit pyamqp:// for amqp uris

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -58,7 +58,7 @@ Optionally you can provide default values ``${ENV_VAR:default_value}``
 .. code-block:: yaml
 
     # foobar.yaml
-    AMQP_URI: amqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}
+    AMQP_URI: pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}
 
 To run your service and set environment variables for it to use:
 
@@ -71,7 +71,7 @@ If you need to quote the values in your YAML file, the explicit ``!env_var`` res
 .. code-block:: yaml
 
     # foobar.yaml
-    AMQP_URI: !env_var "amqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}"
+    AMQP_URI: !env_var "pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}"
 
 Interacting with running services
 ---------------------------------

--- a/nameko/cli/commands.py
+++ b/nameko/cli/commands.py
@@ -68,7 +68,7 @@ class Run(Command):
             help='The YAML configuration file')
 
         parser.add_argument(
-            '--broker', default='amqp://guest:guest@localhost',
+            '--broker', default='pyamqp://guest:guest@localhost',
             help='RabbitMQ broker url')
 
         parser.add_argument(
@@ -101,7 +101,7 @@ class Shell(Command):
     @classmethod
     def init_parser(cls, parser):
         parser.add_argument(
-            '--broker', default='amqp://guest:guest@localhost',
+            '--broker', default='pyamqp://guest:guest@localhost',
             help='RabbitMQ broker url')
         parser.add_argument(
             '--interface', choices=cls.SHELLS,


### PR DESCRIPTION
Fixes remaining URI strings