### PR TITLE
Env var substitution with yaml types

### DIFF
--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -45,9 +45,10 @@ def _replace_env_var(match):
 
 
 def _env_var_constructor(loader, node):
-    value = loader.construct_scalar(node)
-    return ENV_VAR_MATCHER.sub(_replace_env_var, value)
-
+    raw_value = loader.construct_scalar(node)
+    value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
+    new_tag = loader.resolve(yaml.ScalarNode, value, (True, False))
+    return loader.yaml_constructors[new_tag](loader, yaml.ScalarNode(new_tag, value))
 
 def setup_yaml_parser():
     yaml.add_constructor('!env_var', _env_var_constructor)

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -50,6 +50,7 @@ def _env_var_constructor(loader, node):
     new_tag = loader.resolve(yaml.ScalarNode, value, (True, False))
     return loader.yaml_constructors[new_tag](loader, yaml.ScalarNode(new_tag, value))
 
+
 def setup_yaml_parser():
     yaml.add_constructor('!env_var', _env_var_constructor)
     yaml.add_implicit_resolver('!env_var', IMPLICIT_ENV_VAR_MATCHER)


### PR DESCRIPTION
Using http://nameko.readthedocs.io/en/stable/cli.html#environment-variable-substitution - always receive string in nameco config. Via re-throw PyYaml  resolver - receive int/bool/float in config.

Based on: https://groups.google.com/forum/#!topic/nameko-dev/oC2JtEflLtM