### PR TITLE
Add explicite logger for @http decorator

### DIFF
--- a/nameko/web/server.py
+++ b/nameko/web/server.py
@@ -117,7 +117,7 @@ class WebServer(ProviderCollector, SharedExtension):
             wsgi_app,
             protocol=protocol,
             debug=debug,
-            log=getLogger('wsgi')
+            log=getLogger(__name__)
         )
 
     def stop(self):

--- a/nameko/web/server.py
+++ b/nameko/web/server.py
@@ -7,6 +7,7 @@ import eventlet
 from eventlet import wsgi
 from eventlet.support import get_errno
 from eventlet.wsgi import BROKEN_SOCK, BaseHTTPServer, HttpProtocol
+from logging import getLogger
 from werkzeug.exceptions import HTTPException
 from werkzeug.routing import Map
 from werkzeug.wrappers import Request
@@ -115,7 +116,8 @@ class WebServer(ProviderCollector, SharedExtension):
             sock.getsockname(),
             wsgi_app,
             protocol=protocol,
-            debug=debug
+            debug=debug,
+            log=getLogger('wsgi')
         )
 
     def stop(self):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 [testenv]
 deps =
     # oldest supported libraries for each python
-    py27-oldest: eventlet==0.17.2
+    py27-oldest: eventlet==0.17.4
     py{33,34}-oldest: eventlet==0.17.4
     py27-oldest: kombu==3.0.30
     py{33,34}-oldest: kombu==3.0.15

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 [testenv]
 deps =
     # oldest supported libraries for each python
-    py27-oldest: eventlet==0.16.1
+    py27-oldest: eventlet==0.17.2
     py{33,34}-oldest: eventlet==0.17.4
     py27-oldest: kombu==3.0.30
     py{33,34}-oldest: kombu==3.0.15


### PR DESCRIPTION
eventlet.wsgi.Server in "nameko\web\server.py" leave log_output=True and log=None, so all access log like
127.0.0.1 - * [18/Mar/2017 00:57:12] "GET /health HTTP/1.1" 200 140 0.001000
127.0.0.1 - * [18/Mar/2017 00:57:22] "GET /health HTTP/1.1" 200 140 0.002001
127.0.0.1 - * [18/Mar/2017 00:57:23] "GET /health HTTP/1.1" 200 140 0.001008
fall to stderr...

Inside docker and Kubernetes constant flow of non-formatted/unstoppable/non-configurable lines from health checks - big problem.

Explicit configure logger allow receive logs like
`{"asctime": "2017-03-18 01:05:13,662", "msecs": 662.9447937011719, "levelname": "INFO", "process": 9304, "module": "wsgi", "lineno": 566, "args": [], "msg": "127.0.0.1 - * [18/Mar/2017 01:05:13] \"GET /health HTTP/1.1\" 200 140 0.001000", "request_id": null}`

And full control via nameko config
```
...
LOGGING:
  version: 1
...
  loggers:
    wsgi:
      level: INFO
      handlers: [console]
      propagate: False
```

Based on: https://groups.google.com/forum/#!topic/nameko-dev/HN0MP1PjyT4