### PR TITLE
Env var substitution with yaml types

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,13 @@ are in form of *headline.major.minor* numbers. Backwards-compatible changes
 increment the minor version number only.
 
 
+Version 2.6.0
+
+Released: pending
+
+* Improves environment variable substitution to automatically resolve
+  supported scalar values (None, Int, Float and Boolean)
+
 Version 2.5.3
 -------------
 

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -47,8 +47,11 @@ def _replace_env_var(match):
 def _env_var_constructor(loader, node):
     raw_value = loader.construct_scalar(node)
     value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
-    yaml_implicit_resolver = (True, False)
-    new_tag = loader.resolve(yaml.ScalarNode, value, yaml_implicit_resolver)
+    use_implicit_scalar_resolver = True
+    # PyYAML requires tuple/list value for `implicit` arg in `resolve` method
+    # containing two items. Second one is not used so passing `None` here.
+    new_tag = loader.resolve(
+        yaml.ScalarNode, value, (use_implicit_scalar_resolver, None))
     new_node = yaml.ScalarNode(new_tag, value)
     return loader.yaml_constructors[new_tag](loader, new_node)
 

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -48,7 +48,8 @@ def _env_var_constructor(loader, node):
     raw_value = loader.construct_scalar(node)
     value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
     new_tag = loader.resolve(yaml.ScalarNode, value, (True, False))
-    return loader.yaml_constructors[new_tag](loader, yaml.ScalarNode(new_tag, value))
+    new_node = yaml.ScalarNode(new_tag, value)
+    return loader.yaml_constructors[new_tag](loader, new_node)
 
 
 def setup_yaml_parser():

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -47,7 +47,8 @@ def _replace_env_var(match):
 def _env_var_constructor(loader, node):
     raw_value = loader.construct_scalar(node)
     value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
-    new_tag = loader.resolve(yaml.ScalarNode, value, (True, False))
+    yaml_implicit_resolver = (True, False)
+    new_tag = loader.resolve(yaml.ScalarNode, value, yaml_implicit_resolver)
     new_node = yaml.ScalarNode(new_tag, value)
     return loader.yaml_constructors[new_tag](loader, new_node)
 

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -45,9 +45,10 @@ def _replace_env_var(match):
 
 
 def _env_var_constructor(loader, node):
-    value = loader.construct_scalar(node)
-    return ENV_VAR_MATCHER.sub(_replace_env_var, value)
-
+    raw_value = loader.construct_scalar(node)
+    value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
+    new_tag = loader.resolve(yaml.ScalarNode, value, (True, False))
+    return loader.yaml_constructors[new_tag](loader, yaml.ScalarNode(new_tag, value))
 
 def setup_yaml_parser():
     yaml.add_constructor('!env_var', _env_var_constructor)

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -50,6 +50,7 @@ def _env_var_constructor(loader, node):
     new_tag = loader.resolve(yaml.ScalarNode, value, (True, False))
     return loader.yaml_constructors[new_tag](loader, yaml.ScalarNode(new_tag, value))
 
+
 def setup_yaml_parser():
     yaml.add_constructor('!env_var', _env_var_constructor)
     yaml.add_implicit_resolver('!env_var', IMPLICIT_ENV_VAR_MATCHER)

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -60,7 +60,7 @@ class TestConfigEnvironmentVariables(object):
 
     @pytest.mark.parametrize(('yaml_config', 'env_vars', 'expected_config'), [
         # no default value, no env value
-        ('FOO: ${BAR}', {}, {'FOO': ''}),
+        ('FOO: ${BAR}', {}, {'FOO': None}),
         # use default value if env value not provided
         ('FOO: ${BAR:foo}', {}, {'FOO': 'foo'}),
         # use env value

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -86,7 +86,43 @@ class TestConfigEnvironmentVariables(object):
         (
             'FOO: http://${BAR:foo}/${FOO:bar}',
             {'BAR': 'bar', 'FOO': 'foo'},
-            {'FOO': 'http://bar/foo'}),
+            {'FOO': 'http://bar/foo'}
+        ),
+        # can handle int, float and boolean
+        (
+            """
+            FOO:
+                - BAR: ${INT:1}
+                - BAR: ${FLOAT:1.1}
+                - BAR: ${BOOL:True}
+            """,
+            {}, {'FOO': [{'BAR': 1}, {'BAR': 1.1}, {'BAR': True}]}
+        ),
+        (
+            """
+            FOO:
+                - BAR: ${INT}
+                - BAR: ${FLOAT}
+                - BAR: ${BOOL}
+            """,
+            {'INT': '1', 'FLOAT': '1.1', 'BOOL': 'True'},
+            {'FOO': [{'BAR': 1}, {'BAR': 1.1}, {'BAR': True}]}
+        ),
+        # list of scalar values
+        (
+            """
+            FOO:
+                - ${INT_1}
+                - ${INT_2}
+                - ${INT_3}
+            BAR:
+                - 1
+                - 2
+                - 3
+            """,
+            {'INT_1': '1', 'INT_2': '2', 'INT_3': '3'},
+            {'FOO': [1, 2, 3], 'BAR': [1, 2, 3]}
+        )
     ])
     def test_environment_vars_in_config(
         self, yaml_config, env_vars, expected_config


### PR DESCRIPTION
I've added few tests on top of @Trex-Boolat PR (https://github.com/nameko/nameko/pull/421)
They validate/demonstrate resolver is working as expected. 

Additionally looks like `loader.resolve` PyYAML's API is bit weird and requires unused value to be passed, so added a comment why `None` is passed instead.

This change is not strictly speaking backwards compatible so bumping version to `2.6.0`