### PR TITLE
Enable method dispatch.

### DIFF
--- a/nameko/rpc.py
+++ b/nameko/rpc.py
@@ -319,6 +319,9 @@ class ServiceProxy(object):
         return MethodProxy(
             self.worker_ctx, self.service_name, name, self.reply_listener)
 
+    def __getitem__(self, name):
+        return getattr(self, name)
+
 
 class RpcReply(object):
     resp_body = None

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -353,6 +353,9 @@ def test_cluster_proxy_dict_access(
     with ClusterRpcProxy(rabbit_config) as proxy:
         assert proxy['foobar'].spam(ham=3) == 3
 
+    with ClusterRpcProxy(rabbit_config) as proxy:
+        assert proxy['foobar']['spam'](ham=3) == 3
+
 
 def test_recover_from_keyboardinterrupt(
     container_factory, rabbit_manager, rabbit_config


### PR DESCRIPTION
# When call a remote service, method dispatch is more readable and convient.

Now, write code as follows:
 
```
from nameko.standalone.rpc import ClusterRpcProxy
with ClusterRpcProxy(config) as services:
        services["some_service"]["some_method"]("some_args")
```