### PR TITLE
Simplify queue consumer

### DIFF
--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -218,12 +218,7 @@ class QueueConsumer(SharedExtension, ProviderCollector, ConsumerMixin):
 
     @property
     def prefetch_count(self):
-        # The prefetch_count should be larger than max_workers.
-        # If the max_workers <= max_workers,
-        # then there will be a dead lock between
-        # drain_events and on_iteration(since msg.ack in it)
-        # which leads slow down the throughout capacity.
-        return self.container.max_workers + 1
+        return self.container.max_workers
 
     @property
     def accept(self):

--- a/nameko/retry.py
+++ b/nameko/retry.py
@@ -46,7 +46,7 @@ def retry(
             try:
                 return wrapped(*args, **kwargs)
             except for_exceptions:
-                if counter.next() == max_attempts:
+                if next(counter) == max_attempts:
                     raise
                 sleep(retry_delay.next())
 

--- a/nameko/retry.py
+++ b/nameko/retry.py
@@ -1,0 +1,53 @@
+import functools
+import itertools
+from time import sleep
+
+import wrapt
+
+
+class RetryDelay(object):
+    def __init__(self, delay, backoff, max_delay):
+        self.delay = delay
+        self.backoff = backoff
+        self.max_delay = max_delay
+
+    def next(self):
+        if self.backoff:
+            self.delay *= self.backoff
+
+        if self.max_delay:
+            return min(self.delay, self.max_delay)
+
+        return self.delay
+
+
+def retry(
+    wrapped=None, for_exceptions=None, max_attempts=3,
+    delay=1, backoff=1, max_delay=None
+):
+    if wrapped is None:
+        return functools.partial(
+            retry, for_exceptions=for_exceptions, max_attempts=max_attempts,
+            delay=delay, backoff=backoff, max_delay=max_delay
+        )
+
+    for_exceptions = for_exceptions or Exception
+    if max_attempts is None:
+        max_attempts = float('inf')
+
+    retry_delay = RetryDelay(delay, backoff, max_delay)
+
+    @wrapt.decorator
+    def wrapper(wrapped, instance, args, kwargs):
+
+        counter = itertools.count()
+
+        while True:
+            try:
+                return wrapped(*args, **kwargs)
+            except for_exceptions:
+                if counter.next() == max_attempts:
+                    raise
+                sleep(retry_delay.next())
+
+    return wrapper(wrapped)

--- a/nameko/retry.py
+++ b/nameko/retry.py
@@ -50,4 +50,4 @@ def retry(
                     raise
                 sleep(retry_delay.next())
 
-    return wrapper(wrapped)
+    return wrapper(wrapped)  # pylint: disable=E1120

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "requests>=1.2.0",
         "six>=1.9.0",
         "werkzeug>=0.9",
+        "wrapt>=1.0.0",
     ],
     extras_require={
         'dev': [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -60,7 +60,7 @@ def toxiproxy_server():
     def wait_until_server_ready():
         url = "http://{}:{}/proxies".format(TOXIPROXY_HOST, TOXIPROXY_PORT)
         res = requests.get(url)
-        if not res.status_code == 200:
+        if not res.status_code == 200:  # pragma: no cover
             raise NotReady("toxiproxy-server failed to start")
 
     wait_until_server_ready()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,6 @@
 import json
 import subprocess
 import sys
-import time
 import uuid
 
 import pytest
@@ -12,6 +11,7 @@ from six.moves.urllib.parse import urlparse
 from types import ModuleType
 
 from nameko.testing.utils import find_free_port
+from nameko.retry import retry
 
 
 TOXIPROXY_HOST = "127.0.0.1"
@@ -52,7 +52,18 @@ def toxiproxy_server():
         ['toxiproxy-server', '-port', str(port), '-host', host],
         stdout=subprocess.PIPE
     )
-    time.sleep(0.2)  # allow server to start
+
+    class NotReady(Exception):
+        pass
+
+    @retry(delay=0.1, max_attempts=10)
+    def wait_until_server_ready():
+        url = "http://{}:{}/proxies".format(TOXIPROXY_HOST, TOXIPROXY_PORT)
+        res = requests.get(url)
+        if not res.status_code == 200:
+            raise NotReady("toxiproxy-server failed to start")
+
+    wait_until_server_ready()
     yield "{}:{}".format(host, port)
     server.terminate()
 

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -266,7 +266,7 @@ def test_disconnect_with_pending_reply(
             connections = get_rabbit_connections(vhost, rabbit_manager)
             for conn in connections:
                 if conn['name'] == name:
-                    raise ConnectionStillOpen(name)
+                    raise ConnectionStillOpen(name)  # pragma: no cover
 
         def cb(args, kwargs, res, exc_info):
             # trigger a disconnection on the second call.

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -1,7 +1,9 @@
+import itertools
 import socket
 
 import eventlet
 import pytest
+from eventlet.event import Event
 from kombu.connection import Connection
 from kombu.message import Message
 
@@ -10,10 +12,12 @@ from test import skip_if_no_toxiproxy
 from nameko.containers import WorkerContext
 from nameko.exceptions import RemoteError, RpcConnectionError, RpcTimeout
 from nameko.extensions import DependencyProvider
+from nameko.retry import retry
 from nameko.rpc import MethodProxy, Responder, rpc
 from nameko.standalone.rpc import ClusterRpcProxy, ServiceRpcProxy
 from nameko.testing.utils import get_rabbit_connections
-from nameko.testing.waiting import wait_for_call as patch_wait
+from nameko.testing.waiting import wait_for_call
+
 
 # uses autospec on method; needs newer mock for py3
 try:
@@ -215,24 +219,25 @@ def test_multiple_calls_to_result(container_factory, rabbit_config):
         res.result()
 
 
-class ExampleService(object):
-    name = "exampleservice"
-
-    def callback(self):
-        # to be patched out with mock
-        pass  # pragma: no cover
-
-    @rpc
-    def method(self, arg):
-        self.callback()
-        return arg
-
-
 def test_disconnect_with_pending_reply(
-        container_factory, rabbit_manager, rabbit_config):
+    container_factory, rabbit_manager, rabbit_config
+):
+    block = Event()
 
-    example_container = container_factory(ExampleService, rabbit_config)
-    example_container.start()
+    class ExampleService(object):
+        name = "exampleservice"
+
+        def hook(self):
+            pass  # pragma: no cover
+
+        @rpc
+        def method(self, arg):
+            self.hook()
+            block.wait()
+            return arg
+
+    container = container_factory(ExampleService, rabbit_config)
+    container.start()
 
     vhost = rabbit_config['vhost']
 
@@ -243,33 +248,56 @@ def test_disconnect_with_pending_reply(
     container_connection = connections[0]
 
     with ServiceRpcProxy('exampleservice', rabbit_config) as proxy:
+
+        # grab the proxy's connection too, the only other connection
         connections = get_rabbit_connections(vhost, rabbit_manager)
         assert len(connections) == 2
         proxy_connection = [
-            conn for conn in connections if conn != container_connection][0]
+            conn for conn in connections if conn != container_connection
+        ][0]
 
-        def disconnect_once(self):
-            if hasattr(disconnect_once, 'called'):
-                return
-            disconnect_once.called = True
-            rabbit_manager.delete_connection(proxy_connection['name'])
+        counter = itertools.count(start=1)
 
-        with patch.object(ExampleService, 'callback', disconnect_once):
+        class ConnectionStillOpen(Exception):
+            pass
 
-            async = proxy.method.call_async('hello')
+        @retry(for_exceptions=ConnectionStillOpen, delay=0.2)
+        def wait_for_connection_close(name):
+            connections = get_rabbit_connections(vhost, rabbit_manager)
+            for conn in connections:
+                if conn['name'] == name:
+                    raise ConnectionStillOpen(name)
 
-            # if disconnecting while waiting for a reply, call fails
+        def cb(args, kwargs, res, exc_info):
+            # trigger a disconnection on the second call.
+            # release running workers once the connection has been closed
+            count = next(counter)
+            if count == 2:
+                rabbit_manager.delete_connection(proxy_connection['name'])
+                wait_for_connection_close(proxy_connection['name'])
+                block.send(True)
+                return True
+
+        # attach a callback to `hook` so we can close the connection
+        # while there are requests in-flight
+        with wait_for_call(ExampleService, 'hook', callback=cb):
+
+            # make an async call that runs for some time
+            async_call = proxy.method.call_async("hello")
+
+            # make another call that will trigger the disconnection;
+            # expect the blocking proxy to raise when the service reconnects
             with pytest.raises(RpcConnectionError):
-                proxy.method('hello')
+                proxy.method("hello")
 
-            # the failure above also has to consider any other pending calls a
-            # failure, since the reply may have been sent while the queue was
-            # gone (deleted on disconnect, and not added until re-connect)
+            # also expect the running call to raise, since the reply may have
+            # been sent while the queue was gone (deleted on disconnect, and
+            # not added until re-connect)
             with pytest.raises(RpcConnectionError):
-                async.result()
+                async_call.result()
 
-            # proxy should work again afterwards
-            assert proxy.method('hello') == 'hello'
+        # proxy should work again afterwards
+        assert proxy.method("hello") == "hello"
 
 
 def test_timeout_not_needed(container_factory, rabbit_manager, rabbit_config):
@@ -543,7 +571,7 @@ class TestStandaloneProxyDisconnections(object):
             return True
 
         # subsequent calls succeed (after reconnecting via retry policy)
-        with patch_wait(Connection, 'connect', callback=enable_after_retry):
+        with wait_for_call(Connection, 'connect', callback=enable_after_retry):
             assert service_rpc.echo(2) == 2
 
 

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -478,7 +478,7 @@ def test_requeue_on_error(rabbit_manager, rabbit_config, start_containers):
         vhost, "evt-srcservice-eventtype--requeue.handle")
     assert len(queue['consumer_details']) == 1
 
-    counter = itertools.count()
+    counter = itertools.count(start=1)
 
     def entrypoint_fired_twice(worker_ctx, res, exc_info):
         return next(counter) > 1

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -491,6 +491,10 @@ def test_requeue_on_error(rabbit_manager, rabbit_config, start_containers):
             properties=dict(content_type='application/json')
         )
 
+    # stop container to make sure the assertions below aren't made in the
+    # middle of processing an event
+    container.stop()
+
     # the event will be received multiple times as it gets requeued and then
     # consumed again
     assert len(events) > 1

--- a/test/test_queue_consumer.py
+++ b/test/test_queue_consumer.py
@@ -289,19 +289,18 @@ def test_prefetch_count(rabbit_manager, rabbit_config, mock_container):
     queue_consumer2.start()
 
     vhost = rabbit_config['vhost']
-    # the first consumer only has a prefetch_count of 2 and will only consume 2
-    # messages and wait in handler1(). the two handlers will take alternating
-    # messages but are limited to holding 2 un-ACKed messages. Since handler 1
-    # never ACKs, it only ever gets messages 0 annd 2
-    for count in range(5):
-        rabbit_manager.publish(vhost, 'spam', '', str(count), properties=dict(
+    # the two handlers would ordinarily take alternating messages, but are
+    # limited to holding 1 un-ACKed message. Since handler 1 never ACKs, it
+    # only ever gets message 'a'; handler 2 gets the others.
+    for message in ('a', 'b', 'c'):
+        rabbit_manager.publish(vhost, 'spam', '', message, properties=dict(
             content_type=content_type)
         )
 
     # allow the waiting consumer to ack its message
     consumer_continue.send(None)
 
-    assert messages == ['1', '3', '4']
+    assert messages == ['b', 'c']
 
     queue_consumer1.unregister_provider(handler1)
     queue_consumer2.unregister_provider(handler2)

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,0 +1,141 @@
+import pytest
+from mock import Mock, patch
+
+from nameko.retry import retry
+
+
+@pytest.fixture
+def tracker():
+    return Mock()
+
+
+@pytest.yield_fixture(autouse=True)
+def mock_sleep():
+    with patch('nameko.retry.sleep') as patched:
+
+        def total():
+            return sum(delay for (delay,), _ in patched.call_args_list)
+
+        patched.total = total
+        yield patched
+
+
+def test_without_arguments(tracker, mock_sleep):
+
+    @retry
+    def fn():
+        tracker()
+        raise ValueError()
+
+    with pytest.raises(ValueError):
+        fn()
+
+    assert tracker.call_count > 1
+
+
+@pytest.mark.parametrize("exceptions", [ValueError, (ValueError,)])
+def test_retry_for_exceptions(exceptions, tracker):
+    threshold = 10
+
+    @retry(for_exceptions=exceptions, max_attempts=float('inf'))
+    def fn():
+        tracker()
+        if tracker.call_count < threshold:
+            raise ValueError()
+        else:
+            raise KeyError()
+
+    with pytest.raises(KeyError):
+        fn()
+
+    assert tracker.call_count == threshold
+
+
+class TestRetries(object):
+
+    def test_retry_limit(self, tracker):
+        max_attempts = 5
+
+        @retry(max_attempts=max_attempts)
+        def fn():
+            tracker()
+            raise ValueError()
+
+        with pytest.raises(ValueError):
+            fn()
+
+        assert tracker.call_count == 1 + max_attempts
+
+    def test_retry_forever(self, tracker):
+        threshold = 10
+
+        @retry(max_attempts=None)
+        def fn():
+            tracker()
+            if tracker.call_count == threshold:
+                return threshold
+            else:
+                raise ValueError()
+
+        assert fn() == threshold
+        assert tracker.call_count == threshold
+
+
+class TestDelay(object):
+
+    def test_fixed_delay(self, tracker, mock_sleep):
+
+        max_attempts = 5
+        delay = 1
+
+        @retry(max_attempts=max_attempts, delay=delay)
+        def fn():
+            tracker()
+            raise ValueError()
+
+        with pytest.raises(ValueError):
+            fn()
+
+        total_delay = mock_sleep.total()
+        assert total_delay == delay * max_attempts
+
+    def test_backoff(self, tracker, mock_sleep):
+
+        max_attempts = 5
+        delay = 2
+        backoff = 3
+
+        @retry(max_attempts=max_attempts, delay=delay, backoff=backoff)
+        def fn():
+            tracker()
+            raise ValueError()
+
+        with pytest.raises(ValueError):
+            fn()
+
+        total_delay = mock_sleep.total()
+        assert total_delay == sum(
+            delay * (backoff ** attempt)
+            for attempt in range(1, max_attempts + 1)
+        )
+
+    def test_max_delay(self, tracker, mock_sleep):
+
+        max_attempts = 5
+        delay = 1
+        backoff = 2
+        max_delay = delay  # never increase delay, regardless of backoff
+
+        @retry(
+            max_attempts=max_attempts, delay=delay,
+            backoff=backoff, max_delay=max_delay
+        )
+        def fn():
+            tracker()
+            raise ValueError()
+
+        with pytest.raises(ValueError):
+            fn()
+
+        total_delay = mock_sleep.total()
+        assert total_delay == delay * max_attempts

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     py{33,34}-oldest: requests==2.0.0
     oldest: six==1.10.0
     oldest: werkzeug==0.9
+    oldest: wrapt==1.0.0
 
     # pinned library versions (for all pythons)
     pinned: eventlet==0.20.0
@@ -24,6 +25,7 @@ deps =
     pinned: requests==2.12.3
     pinned: six==1.10.0
     pinned: werkzeug==0.11.11
+    pinned: wrapt==1.10.8
 
 setenv =
     branchcoverage: ENABLE_BRANCH_COVERAGE=1


### PR DESCRIPTION
Acks and requeues messages from the active thread, rather than delegating to the queue consumer. This removes the constraint leading to poor performance with small-numbers of workers, and means we can back out the (misguided) prefetch count changes introduced in Nameko 2.5.3.

Also adds a generic retry decorator and robustnesss to a few tests.