### PR TITLE
Add availability to specify section in Config dependency provider

### DIFF
--- a/nameko/dependency_providers.py
+++ b/nameko/dependency_providers.py
@@ -8,5 +8,11 @@ class Config(DependencyProvider):
     """ Dependency provider for accessing configuration values.
     """
 
+    def __init__(self, section=None):
+        self.section = section
+
     def get_dependency(self, worker_ctx):
-        return self.container.config.copy()
+        config = self.container.config.copy()
+        if self.section:
+            return config[self.section]
+        return config


### PR DESCRIPTION
Hi,

I prepare minor change to config dependency provider which will simplify access to the config. 
Nameko config can contain many sections like LOGGING, ENGINE, TSDB_CONFIG, SERVICE_CONFIG, etc. 
In service most of all you need access only to one of this sections.

How it should work:
```
class Service:
    config = Config("SERVICE_CONFIG")

    def test(self):
        my_value = self.config['request_timeout']
```
