### PR TITLE
Context local worker_ctx

### DIFF
--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -370,7 +370,7 @@ class ServiceContainer(object):
                    worker_ctx, '->'.join(worker_ctx.call_id_stack))
 
         with _log_time('ran worker %s', worker_ctx), \
-             push_worker_ctx(worker_ctx):
+                push_worker_ctx(worker_ctx):
             self._inject_dependencies(worker_ctx)
             self._worker_setup(worker_ctx)
 

--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -369,7 +369,8 @@ class ServiceContainer(object):
         _log.debug('call stack for %s: %s',
                    worker_ctx, '->'.join(worker_ctx.call_id_stack))
 
-        with _log_time('ran worker %s', worker_ctx), push_worker_ctx(worker_ctx):
+        with _log_time('ran worker %s', worker_ctx), \
+             push_worker_ctx(worker_ctx):
             self._inject_dependencies(worker_ctx)
             self._worker_setup(worker_ctx)
 

--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -20,6 +20,7 @@ from nameko.extensions import (
     ENTRYPOINT_EXTENSIONS_ATTR, is_dependency, iter_extensions)
 from nameko.log_helpers import make_timing_logger
 from nameko.utils import SpawningSet, import_from_path
+from nameko.globals import push_worker_ctx
 
 _log = getLogger(__name__)
 _log_time = make_timing_logger(_log)
@@ -368,8 +369,7 @@ class ServiceContainer(object):
         _log.debug('call stack for %s: %s',
                    worker_ctx, '->'.join(worker_ctx.call_id_stack))
 
-        with _log_time('ran worker %s', worker_ctx):
-
+        with _log_time('ran worker %s', worker_ctx), push_worker_ctx(worker_ctx):
             self._inject_dependencies(worker_ctx)
             self._worker_setup(worker_ctx)
 

--- a/nameko/dependency_providers.py
+++ b/nameko/dependency_providers.py
@@ -8,11 +8,5 @@ class Config(DependencyProvider):
     """ Dependency provider for accessing configuration values.
     """
 
-    def __init__(self, section=None):
-        self.section = section
-
     def get_dependency(self, worker_ctx):
-        config = self.container.config.copy()
-        if self.section:
-            return config[self.section]
-        return config
+        return self.container.config.copy()

--- a/nameko/dependency_providers.py
+++ b/nameko/dependency_providers.py
@@ -8,5 +8,11 @@ class Config(DependencyProvider):
     """ Dependency provider for accessing configuration values.
     """
 
+    def __init__(self, section=None):
+        self.section = section
+
     def get_dependency(self, worker_ctx):
-        return self.container.config.copy()
+        config = self.container.config.copy()
+        if self.section:
+            return config[self.section]
+        return config

--- a/nameko/globals.py
+++ b/nameko/globals.py
@@ -1,0 +1,15 @@
+from contextlib import contextmanager
+from werkzeug.local import LocalStack
+
+
+_workers_stack = LocalStack()
+worker_ctx = _workers_stack()
+
+
+@contextmanager
+def push_worker_ctx(worker_ctx_):
+    _workers_stack.push(worker_ctx_)
+    try:
+        yield worker_ctx_
+    finally:
+        _workers_stack.pop()

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -233,8 +233,8 @@ class StandaloneProxyBase(object):
 
     def stop(self):
         self._reply_listener.stop()
-        self._worker_ctx_mngr.__exit__(None, None,
-                                       None)  # pylint: disable=E1101
+        # pylint: disable=E1101
+        self._worker_ctx_mngr.__exit__(None, None, None)
 
 
 class ServiceRpcProxy(StandaloneProxyBase):

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -233,7 +233,8 @@ class StandaloneProxyBase(object):
 
     def stop(self):
         self._reply_listener.stop()
-        self._worker_ctx_mngr.__exit__(None, None, None)  # pylint: disable=E1101
+        self._worker_ctx_mngr.__exit__(None, None,
+                                       None)  # pylint: disable=E1101
 
 
 class ServiceRpcProxy(StandaloneProxyBase):

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -227,13 +227,13 @@ class StandaloneProxyBase(object):
 
     def start(self):
         self._worker_ctx_mngr = push_worker_ctx(self._worker_ctx)
-        self._worker_ctx_mngr.__enter__()
+        self._worker_ctx_mngr.__enter__()  # pylint: disable=E1101
         self._reply_listener.setup()
         return self._proxy
 
     def stop(self):
         self._reply_listener.stop()
-        self._worker_ctx_mngr.__exit__(None, None, None)
+        self._worker_ctx_mngr.__exit__(None, None, None)  # pylint: disable=E1101
 
 
 class ServiceRpcProxy(StandaloneProxyBase):

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -14,6 +14,7 @@ from nameko.constants import (
 from nameko.containers import WorkerContext
 from nameko.exceptions import RpcConnectionError, RpcTimeout
 from nameko.extensions import Entrypoint
+from nameko.globals import push_worker_ctx
 from nameko.rpc import ReplyListener, ServiceProxy
 
 _logger = logging.getLogger(__name__)
@@ -216,6 +217,7 @@ class StandaloneProxyBase(object):
             data=context_data)
         self._reply_listener = reply_listener_cls(
             timeout=timeout).bind(container)
+        self._worker_ctx_mngr = None
 
     def __enter__(self):
         return self.start()
@@ -224,11 +226,14 @@ class StandaloneProxyBase(object):
         self.stop()
 
     def start(self):
+        self._worker_ctx_mngr = push_worker_ctx(self._worker_ctx)
+        self._worker_ctx_mngr.__enter__()
         self._reply_listener.setup()
         return self._proxy
 
     def stop(self):
         self._reply_listener.stop()
+        self._worker_ctx_mngr.__exit__(None, None, None)
 
 
 class ServiceRpcProxy(StandaloneProxyBase):


### PR DESCRIPTION
global.worker_ctx context local variable added (request in flask style).
It is pushed in entrypoints and in standalone proxy creation.
It can be used in the scope of request handling e.g. in log formatters for logging call_ids, etc.
We write logs in json, tag them with call_id_stack[0] and store them in elasticsearch. With such approach we are able to retrieve logs from all microservices for specified request.