### PR TITLE
Avoid DeprecationWarning for getfuncargvalue in recent pytest

### DIFF
--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -201,7 +201,11 @@ def fast_teardown(request):
     reorder_fixtures = ('container_factory', 'runner_factory', 'rabbit_config')
     for fixture in reorder_fixtures:
         if fixture in request.funcargnames:
-            request.getfuncargvalue(fixture)
+            # getfuncargvalue is renamed to getfixturevalue in pytest 3.0
+            if hasattr(request, 'getfixturevalue'):
+                request.getfixturevalue(fixture)  # pragma: no cover
+            else:
+                request.getfuncargvalue(fixture)  # pragma: no cover
 
     consumers = []
 


### PR DESCRIPTION
Fixes #445 

I tried to keep compatibility with old PyTest versions while avoiding DeprecationWarnings in new versions. I would appreciate suggestions on how to ensure that the continuous integration gets run both with the currently-used pytest-2.7.3 and a more recent PyTest version.