### PR TITLE
Fix DeprecationWarning for invalid escape sequence in non-raw regexp

### DIFF
--- a/nameko/utils/__init__.py
+++ b/nameko/utils/__init__.py
@@ -92,7 +92,7 @@ def get_redacted_args(entrypoint, *args, **kwargs):
 
     for variable in sensitive_variables:
         keys = []
-        for dict_key, list_index in re.findall("(\w+)|\[(\d+)\]", variable):
+        for dict_key, list_index in re.findall(r"(\w+)|\[(\d+)\]", variable):
             if dict_key:
                 keys.append(dict_key)
             elif list_index:

--- a/nameko/web/server.py
+++ b/nameko/web/server.py
@@ -20,7 +20,7 @@ BindAddress = namedtuple("BindAddress", ['address', 'port'])
 
 
 def parse_address(address_string):
-    address_re = re.compile('^((?P<address>[^:]+):)?(?P<port>\d+)$')
+    address_re = re.compile(r'^((?P<address>[^:]+):)?(?P<port>\d+)$')
     match = address_re.match(address_string)
     if match is None:
         raise ConfigurationError(


### PR DESCRIPTION
Spotted in the Travis CI logs for #446: 
```
---------------- coverage: platform linux, python 3.6.1-final-0 ----------------
/home/travis/build/nameko/nameko/nameko/utils/__init__.py:95: DeprecationWarning: invalid escape sequence \w
  for dict_key, list_index in re.findall("(\w+)|\[(\d+)\]", variable):
<unknown>:95: DeprecationWarning: invalid escape sequence \w
/home/travis/build/nameko/nameko/nameko/web/server.py:23: DeprecationWarning: invalid escape sequence \d
  address_re = re.compile('^((?P<address>[^:]+):)?(?P<port>\d+)$')
<unknown>:23: DeprecationWarning: invalid escape sequence \d
```