### PR TITLE
Enable dict-like access on the ServiceProxy

### DIFF
--- a/nameko/rpc.py
+++ b/nameko/rpc.py
@@ -360,6 +360,9 @@ class ServiceProxy(object):
         return MethodProxy(
             self.worker_ctx, self.service_name, name, self.reply_listener)
 
+    def __getitem__(self, name):
+        """Enable dict-like access on the proxy. """
+        return getattr(self, name)
 
 class RpcReply(object):
     resp_body = None


### PR DESCRIPTION
Enables a call like:

```
def call(service, method, **kwargs):
    with ClusterRpcProxy(config) as cluster_rpc:
        return cluster_rpc[service][method](**kwargs)
```