### PR TITLE
Set attr_name on unbound DependencyProvider

### DIFF
--- a/nameko/extensions.py
+++ b/nameko/extensions.py
@@ -144,6 +144,7 @@ class DependencyProvider(Extension):
         """
         instance = super(DependencyProvider, self).bind(container)
         instance.attr_name = attr_name
+        self.attr_name = attr_name
         return instance
 
     def get_dependency(self, worker_ctx):

--- a/test/test_extensions.py
+++ b/test/test_extensions.py
@@ -86,6 +86,18 @@ def test_extension_uniqueness(container_factory):
     assert dep1.ext != dep2.ext
 
 
+def test_dependency_attr_name(container_factory):
+    c1 = container_factory(Service, config={})
+
+    bound_dep_provider = get_extension(c1, SimpleDependencyProvider)
+    assert bound_dep_provider.attr_name == 'dep'
+
+    dep_provider_declaration = c1.service_cls.dep
+    assert dep_provider_declaration.attr_name == 'dep'
+
+    assert bound_dep_provider != dep_provider_declaration
+
+
 def test_is_bound():
     container = Mock()
 


### PR DESCRIPTION
Lately we have been using service method decorators to handle things like locking, feature-flag switching, validation etc.
These decorators commonly need access to underlying service dependencies - e.g. DB sessions or redis clients.

At worker-run-time, we have to access the dependencies from the service instance. So commonly we've had to:
1) Assume the name of the dependency (e.g. expect that the DB dependency will be named 'session')
or
2) Pass the name of the dependency attr as an argument to the decorator
or
3) Introspect the instance attrs for a dependency of the right type.

This change lets the unbound DependencyProvider instance know its corresponding `attr_name` (after binding has run). This way, if the decorator is implemented as a method on that DependencyProvider,  we have access to the `attr_name` without any of 1, 2, or 3 above.

E.g.

```
class Lock:
    """ The dependency instance """

    @contextmanager
    def apply_lock(self, key):
        print('locked {}'.format(key))
        yield
        print('unlocked {}'.format(key))


class LockDependencyProvider(DependencyProvider):

    def get_dependency(self, worker_ctx):
        return Lock()

    def locked(self, key):
        """ service method decorator """

        @wrapt.decorator
        def wrapper(wrapped, instance, args, kwargs):
            # Now we can get the right runtime dependency
            lock = getattr(instance, self.attr_name)
            with lock.apply_lock(key):
                return wrapped(*args, **kwargs)

        return wrapper


class MyService:

    lock = LockDependencyProvider()

    @rpc
    @lock.locked('mykey')
    def my_method(self):
        pass
```

The above example does not work without this PR, as `attr_name` is only set on the *cloned* DependencyProvider instance that is created when binding.
