### PR TITLE
Rpc remote error

### DIFF
--- a/nameko/exceptions.py
+++ b/nameko/exceptions.py
@@ -36,6 +36,23 @@ class ContainerBeingKilled(Exception):
 registry = {}
 
 
+def remote_error(exc_path):
+    """
+    Register exception as remote error
+
+    Decorator that registers remote exception with matching ``exc_path``
+    to be deserialized to decorated exception instance, rather than
+    wrapped in ``RemoteError``.
+
+    """
+
+    def wrapper(exc_type):
+        registry[exc_path] = exc_type
+        return exc_type
+
+    return wrapper
+
+
 def get_module_path(exc_type):
     """ Return the dotted module path of `exc_type`, including the class name.
 

--- a/nameko/exceptions.py
+++ b/nameko/exceptions.py
@@ -44,6 +44,29 @@ def remote_error(exc_path):
     to be deserialized to decorated exception instance, rather than
     wrapped in ``RemoteError``.
 
+    If a remote service raises an error during an RPC call this decorator
+    can be used to map the remote exception to a local one and handle it
+    as normal::
+
+        @remote_error('service_two.NotFound')
+        class ItemNotFound(LookupError):
+            pass
+
+        class ServiceOne:
+
+            name = 'service-one'
+
+            service_two = RpcProxy('service-two')
+
+            @rpc
+            def get(self, id_, default=None):
+                try:
+                    item = self.service_two.get(id_)
+                except ItemNotFound as exc:
+                    return default
+                else:
+                    return item
+
     """
 
     def wrapper(exc_type):

--- a/test/test_remote_error.py
+++ b/test/test_remote_error.py
@@ -1,0 +1,61 @@
+from nameko.rpc import rpc, RpcProxy
+from nameko.standalone.rpc import ServiceRpcProxy
+from nameko.testing.utils import get_container
+from nameko.testing.services import entrypoint_hook
+import pytest
+
+from nameko.exceptions import remote_error
+
+
+class RemoteError(Exception):
+    pass
+
+
+@remote_error('test.test_remote_error.RemoteError')
+class LocalError(Exception):
+    pass
+
+
+class RemoteService:
+
+    name = 'remote-service'
+
+    @rpc
+    def raise_(self):
+        raise RemoteError('Ya!')
+
+
+class LocalService:
+
+    name = 'local-service'
+
+    remote = RpcProxy('remote-service')
+
+    @rpc
+    def catch(self):
+        try:
+            self.remote.raise_()
+        except LocalError as exc:
+            return 'Got {}'.format(exc.args[0])
+
+
+def test_for_rpc_proxy_standalone(container_factory, rabbit_config):
+
+    container = container_factory(RemoteService, rabbit_config)
+    container.start()
+
+    with ServiceRpcProxy('remote-service', rabbit_config) as proxy:
+        with pytest.raises(LocalError) as exc:
+            proxy.raise_()
+        assert 'LocalError' in str(exc)
+        assert 'Ya!' == str(exc.value)
+
+
+def test_for_rpc_proxy_dependency_provider(runner_factory, rabbit_config):
+
+    runner = runner_factory(rabbit_config, RemoteService, LocalService)
+    runner.start()
+
+    container = get_container(runner, LocalService)
+    with entrypoint_hook(container, 'catch') as entrypoint:
+        assert entrypoint() == "Got Ya!"


### PR DESCRIPTION
This PR ads a decorator for registering remote exceptions to existing exception registry, thus adding the ability to handle RPC exceptions inside RPC entrypoint methods with using standard error handling and without the need of "unwrapping" the original exceptions from `RemoteError` and loosing the original args.

I think that the existing "path" mapping used for "transporting" internal errors works well for custom errors too and that the little decorator brings a straightforward, clear and readable solution from Nameko internals to the API of the framework.