### PR TITLE
Rabbit mgmt auth headers

### DIFF
--- a/nameko/testing/rabbit.py
+++ b/nameko/testing/rabbit.py
@@ -2,6 +2,8 @@ import json
 
 import six
 from requests import ConnectionError, HTTPError, Session
+from requests.auth import HTTPBasicAuth
+from requests.utils import urldefragauth, get_auth_from_url
 from six.moves.urllib.parse import quote  # pylint: disable=E0401
 
 
@@ -16,8 +18,15 @@ class Client(object):
     """Pyrabbit replacement using requests instead of httplib2 """
 
     def __init__(self, uri):
+
+        # move basic auth creds into headers to avoid
+        # https://github.com/requests/requests/issues/4275
+        username, password = get_auth_from_url(uri)
+        uri = urldefragauth(uri)
+
         self._base_url = '{}/api'.format(uri)
         self._session = Session()
+        self._session.auth = HTTPBasicAuth(username, password)
         self._session.headers['content-type'] = 'application/json'
         self._verify_api_connection()
 

--- a/nameko/testing/rabbit.py
+++ b/nameko/testing/rabbit.py
@@ -3,7 +3,7 @@ import json
 import six
 from requests import ConnectionError, HTTPError, Session
 from requests.auth import HTTPBasicAuth
-from requests.utils import urldefragauth, get_auth_from_url
+from requests.utils import get_auth_from_url, urldefragauth
 from six.moves.urllib.parse import quote  # pylint: disable=E0401
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,7 @@ deps =
     oldest: kombu==3.0.30
     oldest: mock==1.2.0
     oldest: path.py==6.2
-    py27-oldest: requests==1.2.0
-    py{34,35,36}-oldest: requests==2.0.0
+    oldest: requests==2.4.3
     oldest: six==1.10.0
     oldest: werkzeug==0.9
     oldest: wrapt==1.0.0


### PR DESCRIPTION
Pass credentials for management API as headers to work around requests/requests#4275