### PR TITLE
Refactor constants into constants.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 .DS_Store
-.codeintel
 .coverage
-.DS_Store
-.idea
 *.pyc
-*.sublime-*
 _py_cache
 docs/build
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .codeintel
 .coverage
 .DS_Store
+.idea
 *.pyc
 *.sublime-*
 _py_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,18 @@ sudo: false
 language: python
 
 services:
-    - rabbitmq
+  - docker
 
 before_install:
+    # start rabbitmq
+    - docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 -e RABBITMQ_DEFAULT_USER=guest -e RABBITMQ_DEFAULT_PASS=guest rabbitmq:3.6.6-management
+    # install toxiproxy
     - mkdir $PWD/bin
     - wget -O $PWD/bin/toxiproxy-server https://github.com/Shopify/toxiproxy/releases/download/v2.0.0/toxiproxy-server-linux-amd64
     - chmod +x $PWD/bin/toxiproxy-server
     - export PATH=$PATH:$PWD/bin/
+    # work around https://github.com/travis-ci/travis-ci/issues/7940
+    - sudo rm -f /etc/boto.cfg
 
 addons:
   apt_packages:

--- a/nameko/amqp/publish.py
+++ b/nameko/amqp/publish.py
@@ -5,12 +5,7 @@ from kombu import Connection
 from kombu.pools import connections, producers
 from six.moves import queue as Queue
 
-from nameko.constants import DEFAULT_RETRY_POLICY
-
-
-# delivery_mode
-NON_PERSISENT = 1
-PERSISTENT = 2
+from nameko.constants import DEFAULT_RETRY_POLICY, PERSISTENT
 
 
 class UndeliverableMessage(Exception):

--- a/nameko/constants.py
+++ b/nameko/constants.py
@@ -18,3 +18,8 @@ AUTH_TOKEN_CONTEXT_KEY = 'auth_token'
 LANGUAGE_CONTEXT_KEY = 'language'
 USER_ID_CONTEXT_KEY = 'user_id'
 USER_AGENT_CONTEXT_KEY = 'user_agent'
+
+# delivery_mode
+HEADER_PREFIX = "nameko"
+NON_PERSISTENT = 1
+PERSISTENT = 2

--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -18,7 +18,7 @@ from nameko.amqp.publish import Publisher as PublisherCore
 from nameko.amqp.publish import get_connection
 from nameko.amqp.utils import verify_amqp_uri
 from nameko.constants import (
-    AMQP_URI_CONFIG_KEY, DEFAULT_HEARTBEAT, DEFAULT_SERIALIZER,
+    AMQP_URI_CONFIG_KEY, DEFAULT_HEARTBEAT, DEFAULT_SERIALIZER, HEADER_PREFIX,
     HEARTBEAT_CONFIG_KEY, SERIALIZER_CONFIG_KEY
 )
 from nameko.exceptions import ContainerBeingKilled
@@ -29,10 +29,6 @@ from nameko.utils.retry import retry
 
 
 _log = getLogger(__name__)
-
-# delivery_mode
-PERSISTENT = 2
-HEADER_PREFIX = "nameko"
 
 
 class HeaderEncoder(object):

--- a/nameko/standalone/events.py
+++ b/nameko/standalone/events.py
@@ -1,8 +1,9 @@
 from kombu import Exchange
 
 from nameko.amqp.publish import Publisher
-from nameko.constants import DEFAULT_SERIALIZER, SERIALIZER_CONFIG_KEY
-from nameko.messaging import AMQP_URI_CONFIG_KEY, PERSISTENT
+from nameko.constants import (
+    AMQP_URI_CONFIG_KEY, DEFAULT_SERIALIZER, PERSISTENT, SERIALIZER_CONFIG_KEY
+)
 
 
 def get_event_exchange(service_name):

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -322,7 +322,7 @@ def web_config(empty_config):
     port = find_free_port()
 
     cfg = empty_config
-    cfg[WEB_SERVER_CONFIG_KEY] = str(port)
+    cfg[WEB_SERVER_CONFIG_KEY] = "127.0.0.1:{}".format(port)
     return cfg
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,11 @@ deps =
     pinned: werkzeug==0.11.11
     pinned: wrapt==1.10.8
 
+    # we can't test eventlet>0.20.1 in our py27 CI environment until the fix
+    # in https://github.com/eventlet/eventlet/issues/401 is released
+    py27-latest: eventlet==0.20.1
+    py27-examples: eventlet==0.20.1
+
 setenv =
     branchcoverage: ENABLE_BRANCH_COVERAGE=1
     examples: ENABLE_BRANCH_COVERAGE=1


### PR DESCRIPTION
This allows for standalone/events.py to be imported into a
Jython environment that does not support eventlet.

Also updated .gitignore to remove dev-specific directories and a duplicate .DS_Store entry.

I needed to generate standalone nameko events from a Jython application, and when I tried to import nameko.standalone.events it also pulled in nameko.messaging, which pulled in eventlet, which doesn't work in Jython.

By refactoring all of the constants into constants.py I was able to import the module into Jython without pulling in eventlet.

The NON_PERSISENT constant turned out to be unused in publish.py so I corrected the spelling and placed it in constants.py.