### PR TITLE
Trusty fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 language: python
 
 services:
-    - rabbitmq
+  - docker
 
 before_install:
+    - docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 -e RABBITMQ_DEFAULT_USER=guest -e RABBITMQ_DEFAULT_PASS=guest rabbitmq:3.6.6-management
     - mkdir $PWD/bin
     - wget -O $PWD/bin/toxiproxy-server https://github.com/Shopify/toxiproxy/releases/download/v2.0.0/toxiproxy-server-linux-amd64
     - chmod +x $PWD/bin/toxiproxy-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ services:
   - docker
 
 before_install:
+    # start rabbitmq
     - docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 -e RABBITMQ_DEFAULT_USER=guest -e RABBITMQ_DEFAULT_PASS=guest rabbitmq:3.6.6-management
+    # install toxiproxy
     - mkdir $PWD/bin
     - wget -O $PWD/bin/toxiproxy-server https://github.com/Shopify/toxiproxy/releases/download/v2.0.0/toxiproxy-server-linux-amd64
     - chmod +x $PWD/bin/toxiproxy-server
     - export PATH=$PATH:$PWD/bin/
+    # work around https://github.com/travis-ci/travis-ci/issues/7940
+    - sudo rm -f /etc/boto.cfg
 
 addons:
   apt_packages:

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -322,7 +322,7 @@ def web_config(empty_config):
     port = find_free_port()
 
     cfg = empty_config
-    cfg[WEB_SERVER_CONFIG_KEY] = str(port)
+    cfg[WEB_SERVER_CONFIG_KEY] = "127.0.0.1:{}".format(port)
     return cfg
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ deps =
     # we can't test eventlet>0.20.1 in our py27 CI environment until the fix
     # in https://github.com/eventlet/eventlet/issues/401 is released
     py27-latest: eventlet==0.20.1
+    py27-examples: eventlet==0.20.1
 
 setenv =
     branchcoverage: ENABLE_BRANCH_COVERAGE=1

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,10 @@ deps =
     pinned: werkzeug==0.11.11
     pinned: wrapt==1.10.8
 
+    # we can't test eventlet>0.20.1 in our py27 CI environment until the fix
+    # in https://github.com/eventlet/eventlet/issues/401 is released
+    py27-latest: eventlet==0.20.1
+
 setenv =
     branchcoverage: ENABLE_BRANCH_COVERAGE=1
     examples: ENABLE_BRANCH_COVERAGE=1


### PR DESCRIPTION
Fixes to get the test suite passing on the new Travis infrastructure:

* Limiting RabbitMQ version to 3.6.6 since the management API is slower in later versions (several tests need rewriting)
* Excluding Eventlet 0.21.0 on Py27, since https://github.com/eventlet/eventlet/issues/401 now bites us
* Workaround travis-ci/travis-ci#7940
* Explicitly bind the webserver to a specific IP, since ports are now used on other IP addresses and were clashing (SO_REUSEADDR is not set)