### PR TITLE
Close connections when deleting vhost during tests

### DIFF
--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -96,10 +96,15 @@ def rabbit_manager(request):
 
 @pytest.yield_fixture(scope='session')
 def vhost_pipeline(request, rabbit_manager):
+    from collections import Iterable
     from six.moves.urllib.parse import urlparse  # pylint: disable=E0401
     import random
+    import socket
     import string
+    from kombu.pools import connections
     from nameko.testing.utils import ResourcePipeline
+    from nameko.utils.retry import retry
+    from requests.exceptions import HTTPError
 
     rabbit_amqp_uri = request.config.getoption('RABBIT_AMQP_URI')
     uri_parts = urlparse(rabbit_amqp_uri)
@@ -115,8 +120,17 @@ def vhost_pipeline(request, rabbit_manager):
         )
         return vhost
 
+    @retry(for_exceptions=(HTTPError, socket.timeout), delay=1, max_attempts=9)
     def destroy(vhost):
         rabbit_manager.delete_vhost(vhost)
+
+        # make sure connections for this vhost are also destroyed.
+        vhost_pools = [
+            pool for key, pool in list(connections.items())
+            if isinstance(key, Iterable) and key[4] == vhost
+        ]
+        for pool in vhost_pools:
+            pool.force_close_all()
 
     pipeline = ResourcePipeline(create, destroy)
 


### PR DESCRIPTION
We noticed when running our service tests, that even though each vhost is being deleted, there are connections left behind for those vhosts.
It appears these are connections for each of the producers started during the test run.

This fix ensures all vhost connections are closed when the vhost is deleted (in a brute force way).  Possibly the full fix is to give producers a full extension lifecycle like other entrypoints, so they get torn down properly?

It also adds a retry to ensure the vhost is deleted.