### PR TITLE
Deploy at end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,17 @@ matrix:
     - stage: test
       python: 3.6
       env: TOX_ENV=py36-latest-lib
+    - stage: deploy
+        script: skip
+        deploy:
+          provider: pypi
+          user: onefinestay
+          password:
+            secure: Mwinp9cxGaGe/KjGFcO+T7MAgLvy5yFNeYCq9zpGniuSXsp/AFH3JIS1kWBv71tMC8S2N5kwRMVXoHNMqJt+Iq/EmYIY6vbMK8GijAUqLo8KsbxgmigWTXTn6IHKDO4gwYmQt8BDYJmbq6CNeVVCHMxWyP0Y24S25y7N35oIroU=
+          on:
+            tags: true
+            repo: nameko/nameko
+          distributions: "sdist bdist_wheel"
     - stage: mastereventlet
       python: 2.7
       env: TOX_ENV=py27-mastereventlet-lib
@@ -105,12 +116,4 @@ matrix:
 script:
   - tox -e $TOX_ENV
 
-deploy:
-  provider: pypi
-  user: onefinestay
-  password:
-    secure: Mwinp9cxGaGe/KjGFcO+T7MAgLvy5yFNeYCq9zpGniuSXsp/AFH3JIS1kWBv71tMC8S2N5kwRMVXoHNMqJt+Iq/EmYIY6vbMK8GijAUqLo8KsbxgmigWTXTn6IHKDO4gwYmQt8BDYJmbq6CNeVVCHMxWyP0Y24S25y7N35oIroU=
-  on:
-    tags: true
-    repo: nameko/nameko
-  distributions: "sdist bdist_wheel"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,16 +80,16 @@ matrix:
       python: 3.6
       env: TOX_ENV=py36-latest-lib
     - stage: deploy
-        script: skip
-        deploy:
-          provider: pypi
-          user: onefinestay
-          password:
-            secure: Mwinp9cxGaGe/KjGFcO+T7MAgLvy5yFNeYCq9zpGniuSXsp/AFH3JIS1kWBv71tMC8S2N5kwRMVXoHNMqJt+Iq/EmYIY6vbMK8GijAUqLo8KsbxgmigWTXTn6IHKDO4gwYmQt8BDYJmbq6CNeVVCHMxWyP0Y24S25y7N35oIroU=
-          on:
-            tags: true
-            repo: nameko/nameko
-          distributions: "sdist bdist_wheel"
+      script: skip
+      deploy:
+        provider: pypi
+        user: onefinestay
+        password:
+          secure: Mwinp9cxGaGe/KjGFcO+T7MAgLvy5yFNeYCq9zpGniuSXsp/AFH3JIS1kWBv71tMC8S2N5kwRMVXoHNMqJt+Iq/EmYIY6vbMK8GijAUqLo8KsbxgmigWTXTn6IHKDO4gwYmQt8BDYJmbq6CNeVVCHMxWyP0Y24S25y7N35oIroU=
+        on:
+          tags: true
+          repo: nameko/nameko
+        distributions: "sdist bdist_wheel"
     - stage: mastereventlet
       python: 2.7
       env: TOX_ENV=py27-mastereventlet-lib


### PR DESCRIPTION
The top-level deploy task runs on every successful job, whereas we actually want it to only run when all the required jobs have passed.

Moving deployment into a build stage means it will only execute when all the previous stages have passed.