### PR TITLE
Fix logging fail when exception has unicode characters

### DIFF
--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -387,7 +387,7 @@ class ServiceContainer(object):
                 with _log_time('ran handler for %s', worker_ctx):
                     result = method(*worker_ctx.args, **worker_ctx.kwargs)
             except Exception as exc:
-                _log.info('error handling worker %s: %s', worker_ctx, exc,
+                _log.info('error handling worker %s: %s', worker_ctx, exc.message.decode('utf-8'),
                           exc_info=True)
                 exc_info = sys.exc_info()
 


### PR DESCRIPTION
Hello,

When my service raises en error (with some non-ascii characters in message), exception and its trace is not visible, because logging cannot process such message:
```
<WorkerContext [PS.storeFollowingEvent] at 0x7f0e141101d0>
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 859, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 732, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 471, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 335, in getMessage
    msg = msg % self.args
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)
Logged from file containers.py, line 393
127.0.0.1 - - [14/Nov/2017 19:29:07] "POST /storeFollowingEvent/252525252525/99999999999/1?moment=234567891 HTTP/1.1" 500 204 0.015099
```
Actionally, message is cyrillic:
```
ОШИБКА:  нулевое значение в столбце "id" нарушает ограничение NOT NULL
DETAIL:  Ошибочная строка содержит (1977-06-08 07:44:51, 99999999999, t, null).
```

When I add ```decode('utf-8')```, problem is away, exception is printed OK.

Regards, 
Evgeniy