### PR TITLE
Enable multi-method URLs

### DIFF
--- a/nameko/web/handlers.py
+++ b/nameko/web/handlers.py
@@ -23,7 +23,7 @@ class HttpRequestHandler(Entrypoint):
         super(HttpRequestHandler, self).__init__(**kwargs)
 
     def get_url_rule(self):
-        return Rule(self.url, methods=self.method.split(',')
+        return Rule(self.url, methods=self.method.split(','))
 
     def setup(self):
         self.server.register_provider(self)

--- a/nameko/web/handlers.py
+++ b/nameko/web/handlers.py
@@ -23,7 +23,7 @@ class HttpRequestHandler(Entrypoint):
         super(HttpRequestHandler, self).__init__(**kwargs)
 
     def get_url_rule(self):
-        return Rule(self.url, methods=[self.method])
+        return Rule(self.url, methods=self.method.split(',')
 
     def setup(self):
         self.server.register_provider(self)


### PR DESCRIPTION
Sometimes a URL method shares functional code, and the http method is used further downstream. This simple change enables a DRY approach to these types of URLs.