### PR TITLE
Enable multi-method URL declarations

### DIFF
--- a/docs/built_in_extensions.rst
+++ b/docs/built_in_extensions.rst
@@ -48,6 +48,8 @@ HTTP
 
 The HTTP entrypoint is built on top of `werkzeug <http://werkzeug.pocoo.org/>`_, and supports all the standard HTTP methods (GET/POST/DELETE/PUT etc)
 
+The HTTP entrypoint can specify multiple HTTP methods for a single URL as a comma-separated list. See example below.
+
 Service methods must return one of:
 
 - a string, which becomes the response body

--- a/docs/examples/http.py
+++ b/docs/examples/http.py
@@ -13,3 +13,7 @@ class HttpService:
     @http('POST', '/post')
     def do_post(self, request):
         return u"received: {}".format(request.get_data(as_text=True))
+
+    @http('GET,PUT,POST,DELETE', '/multi')
+    def get_method(self, request):
+        return request.method

--- a/docs/examples/http.py
+++ b/docs/examples/http.py
@@ -13,3 +13,7 @@ class HttpService:
     @http('POST', '/post')
     def do_post(self, request):
         return u"received: {}".format(request.get_data(as_text=True))
+
+    @http('GET,PUT,POST,DELETE', '/multi/<value>')
+    def get_method(self, request, value):
+        return u"{}: {}".format(request.method, value)

--- a/docs/examples/http.py
+++ b/docs/examples/http.py
@@ -15,5 +15,5 @@ class HttpService:
         return u"received: {}".format(request.get_data(as_text=True))
 
     @http('GET,PUT,POST,DELETE', '/multi')
-    def get_method(self, request):
+    def do_multi(self, request):
         return request.method

--- a/docs/examples/http.py
+++ b/docs/examples/http.py
@@ -14,6 +14,6 @@ class HttpService:
     def do_post(self, request):
         return u"received: {}".format(request.get_data(as_text=True))
 
-    @http('GET,PUT,POST,DELETE', '/multi/<value>')
-    def get_method(self, request, value):
-        return u"{}: {}".format(request.method, value)
+    @http('GET,PUT,POST,DELETE', '/multi')
+    def get_method(self, request):
+        return request.method

--- a/docs/examples/http.py
+++ b/docs/examples/http.py
@@ -13,7 +13,3 @@ class HttpService:
     @http('POST', '/post')
     def do_post(self, request):
         return u"received: {}".format(request.get_data(as_text=True))
-
-    @http('GET,PUT,POST,DELETE', '/multi')
-    def get_method(self, request):
-        return request.method

--- a/docs/examples/test/test_examples.py
+++ b/docs/examples/test/test_examples.py
@@ -32,6 +32,22 @@ class TestHttp(object):
         assert res.status_code == 200
         assert res.text == u'received: 你好'
 
+        res = web_session.get("/multi")
+        assert res.status_code == 200
+        assert res.text == 'GET'
+
+        res = web_session.put("/multi")
+        assert res.status_code == 200
+        assert res.text == 'PUT'
+
+        res = web_session.post("/multi")
+        assert res.status_code == 200
+        assert res.text == 'POST'
+
+        res = web_session.delete("/multi")
+        assert res.status_code == 200
+        assert res.text == 'DELETE'
+
     def test_advanced(self, container_factory, web_config, web_session):
 
         from examples.advanced_http import Service

--- a/docs/examples/test/test_examples.py
+++ b/docs/examples/test/test_examples.py
@@ -32,6 +32,18 @@ class TestHttp(object):
         assert res.status_code == 200
         assert res.text == u'received: 你好'
 
+        res = web_session.get("/multi")
+        assert res.text == 'GET'
+
+        res = web_session.put("/multi")
+        assert res.text == 'PUT'
+
+        res = web_session.post("/multi")
+        assert res.text == 'POST'
+
+        res = web_session.delete("/multi")
+        assert res.text == 'DELETE'
+
     def test_advanced(self, container_factory, web_config, web_session):
 
         from examples.advanced_http import Service

--- a/docs/examples/test/test_examples.py
+++ b/docs/examples/test/test_examples.py
@@ -32,18 +32,6 @@ class TestHttp(object):
         assert res.status_code == 200
         assert res.text == u'received: 你好'
 
-        res = web_session.get("/multi")
-        assert res.text == 'GET'
-
-        res = web_session.put("/multi")
-        assert res.text == 'PUT'
-
-        res = web_session.post("/multi")
-        assert res.text == 'POST'
-
-        res = web_session.delete("/multi")
-        assert res.text == 'DELETE'
-
     def test_advanced(self, container_factory, web_config, web_session):
 
         from examples.advanced_http import Service

--- a/nameko/web/handlers.py
+++ b/nameko/web/handlers.py
@@ -23,7 +23,7 @@ class HttpRequestHandler(Entrypoint):
         super(HttpRequestHandler, self).__init__(**kwargs)
 
     def get_url_rule(self):
-        return Rule(self.url, methods=[self.method])
+        return Rule(self.url, methods=self.method.split(','))
 
     def setup(self):
         self.server.register_provider(self)

--- a/test/web/test_http_handler.py
+++ b/test/web/test_http_handler.py
@@ -19,8 +19,11 @@ class ExampleService(object):
     def do_post(self, request):
         data = json.loads(request.get_data(as_text=True))
         value = data['value']
-
         return value
+
+    @http('GET,PUT,POST', '/multi')
+    def do_multi(self, request):
+        return request.method
 
     @http('GET', '/custom')
     def do_custom(self, request):
@@ -71,6 +74,21 @@ def test_post(web_session):
         'value': 'foo',
     }))
     assert rv.text == "foo"
+
+
+def test_multi_get(web_session):
+    rv = web_session.get('/multi')
+    assert rv.text == "GET"
+
+
+def test_multi_put(web_session):
+    rv = web_session.put('/multi')
+    assert rv.text == "PUT"
+
+
+def test_multi_post(web_session):
+    rv = web_session.post('/multi')
+    assert rv.text == "POST"
 
 
 def test_custom_response(web_session):


### PR DESCRIPTION
Rather than specifying multiple (duplicate) URLs, this change allows specifying a CSV for the methods allowed.

For example:

```
    @http('GET', '/<string(length=4):book_id>/publish/<feed_name>')
    @http('PUT', '/<string(length=4):book_id>/publish/<feed_name>')
```
becomes
```
    @http('GET,PUT', '/<string(length=4):book_id>/publish/<feed_name>')
```
This is very handy when the methods share the same functional code, and reply on the HTTP method for augmentation (for example, 'Do it' vs 'Show me it')

This is a change is backwards compatible, as a 'split' always greats a list - even if there are no matches.

`"GET".split(',')` => `["GET"]`
`"GET,PUT".split(',')` => `["GET", "PUT"]`