### PR TITLE
Message ack regression

### DIFF
--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -8,7 +8,6 @@ from functools import partial
 from logging import getLogger
 
 import six
-from amqp.exceptions import RecoverableConnectionError
 from eventlet.event import Event
 from kombu import Connection
 from kombu.common import maybe_declare
@@ -25,7 +24,6 @@ from nameko.exceptions import ContainerBeingKilled
 from nameko.extensions import (
     DependencyProvider, Entrypoint, ProviderCollector, SharedExtension
 )
-from nameko.utils.retry import retry
 
 
 _log = getLogger(__name__)

--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -472,8 +472,7 @@ class Consumer(Entrypoint, HeaderDecoder):
         if exc_info is not None and self.requeue_on_error:
             self.queue_consumer.requeue_message(message)
         else:
-            import eventlet
-            eventlet.spawn(self.queue_consumer.ack_message, message)
+            self.queue_consumer.ack_message(message)
 
 
 consume = Consumer.decorator

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,6 @@ import sys
 import uuid
 from types import ModuleType
 
-import eventlet
 import pytest
 import requests
 from mock import ANY, patch
@@ -161,7 +160,7 @@ def toxiproxy(toxiproxy_server, rabbit_config):
     yield controller
     controller.reset()
 
-    
+
 @pytest.yield_fixture
 def fake_module():
     module = ModuleType("fake_module")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -53,8 +53,7 @@ def toxiproxy_server():
     host = TOXIPROXY_HOST
     port = TOXIPROXY_PORT
     server = subprocess.Popen(
-        ['toxiproxy-server', '-port', str(port), '-host', host],
-        stdout=subprocess.PIPE
+        ['toxiproxy-server', '-port', str(port), '-host', host]
     )
 
     class NotReady(Exception):
@@ -160,6 +159,11 @@ def toxiproxy(toxiproxy_server, rabbit_config):
     controller = Controller(proxy_uri)
     yield controller
     controller.reset()
+
+    # delete proxy
+    requests.delete(
+        'http://{}/proxies/{}'.format(toxiproxy_server, proxy_name)
+    )
 
 
 @pytest.yield_fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -161,13 +161,7 @@ def toxiproxy(toxiproxy_server, rabbit_config):
     yield controller
     controller.reset()
 
-    # delete proxy
-    # allow some grace period to ensure we don't remove the proxy before
-    # other fixtures have torn down
-    resource = 'http://{}/proxies/{}'.format(toxiproxy_server, proxy_name)
-    eventlet.spawn_after(10, requests.delete, resource)
-
-
+    
 @pytest.yield_fixture
 def fake_module():
     module = ModuleType("fake_module")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@ import sys
 import uuid
 from types import ModuleType
 
+import eventlet
 import pytest
 import requests
 from mock import ANY, patch
@@ -161,9 +162,10 @@ def toxiproxy(toxiproxy_server, rabbit_config):
     controller.reset()
 
     # delete proxy
-    requests.delete(
-        'http://{}/proxies/{}'.format(toxiproxy_server, proxy_name)
-    )
+    # allow some grace period to ensure we don't remove the proxy before
+    # other fixtures have torn down
+    resource = 'http://{}/proxies/{}'.format(toxiproxy_server, proxy_name)
+    eventlet.spawn_after(10, requests.delete, resource)
 
 
 @pytest.yield_fixture

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -685,6 +685,8 @@ class TestConsumerDisconnections(object):
             while not lock._waiters:
                 eventlet.sleep()  # pragma: no cover
             toxiproxy.disable()
+            # allow connection to close before releasing worker
+            eventlet.sleep(.1)
             lock.release()
 
         # entrypoint will return and attempt to ack initiating message
@@ -731,6 +733,8 @@ class TestConsumerDisconnections(object):
             while not lock._waiters:
                 eventlet.sleep()  # pragma: no cover
             toxiproxy.disable()
+            # allow connection to close before releasing worker
+            eventlet.sleep(.1)
             lock.release()
 
         # entrypoint will return and attempt to requeue initiating message

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 
 import eventlet
 import pytest
+from eventlet.semaphore import Semaphore
 from kombu import Exchange, Queue
 from kombu.connection import Connection
 from mock import Mock, call, patch
@@ -491,7 +492,7 @@ class TestConsumerDisconnections(object):
 
     @pytest.fixture
     def lock(self):
-        return eventlet.Semaphore()
+        return Semaphore()
 
     @pytest.fixture
     def tracker(self):

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import itertools
 import socket
 from contextlib import contextmanager
 

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -682,7 +682,7 @@ class TestConsumerDisconnections(object):
         # break connection while the worker is active, then release
         publish('foo')
         while not lock._waiters:
-            eventlet.sleep()
+            eventlet.sleep()  # pragma: no cover
         toxiproxy.disable()
         lock.release()
         toxiproxy.enable()

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -799,7 +799,7 @@ class TestRpcConsumerDisconnections(object):
         # break connection while the worker is active, then release
         res = service_rpc.echo.call_async("foo")
         while not lock._waiters:
-            eventlet.sleep()
+            eventlet.sleep()  # pragma: no cover
         toxiproxy.disable()
         lock.release()
         toxiproxy.enable()

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 import eventlet
 import pytest
 from eventlet.event import Event
+from eventlet.semaphore import Semaphore
 from greenlet import GreenletExit  # pylint: disable=E0611
 from kombu.connection import Connection
 from mock import Mock, call, create_autospec, patch
@@ -626,7 +627,7 @@ class TestRpcConsumerDisconnections(object):
 
     @pytest.fixture
     def lock(self):
-        return eventlet.Semaphore()
+        return Semaphore()
 
     @pytest.fixture
     def tracker(self):

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -802,6 +802,8 @@ class TestRpcConsumerDisconnections(object):
             while not lock._waiters:
                 eventlet.sleep()  # pragma: no cover
             toxiproxy.disable()
+            # allow connection to close before releasing worker
+            eventlet.sleep(.1)
             lock.release()
 
         # entrypoint will return and reply will be received,

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -1,4 +1,5 @@
 import uuid
+from contextlib import contextmanager
 
 import eventlet
 import pytest
@@ -8,7 +9,7 @@ from kombu.connection import Connection
 from mock import Mock, call, create_autospec, patch
 from six.moves import queue
 
-from nameko.constants import MAX_WORKERS_CONFIG_KEY
+from nameko.constants import HEARTBEAT_CONFIG_KEY, MAX_WORKERS_CONFIG_KEY
 from nameko.containers import WorkerContext
 from nameko.events import event_handler
 from nameko.exceptions import (
@@ -589,6 +590,193 @@ def test_rpc_consumer_cannot_exit_with_providers(
 
     # kill off task_a's misbehaving rpc provider
     container.kill()
+
+
+@skip_if_no_toxiproxy
+class TestRpcConsumerDisconnections(object):
+    """ Test and demonstrate behaviour under poor network conditions.
+    """
+    @pytest.yield_fixture(autouse=True)
+    def fast_reconnects(self):
+
+        @contextmanager
+        def establish_connection(self):
+            with self.create_connection() as conn:
+                conn.ensure_connection(
+                    self.on_connection_error,
+                    self.connect_max_retries,
+                    interval_start=0.1,
+                    interval_step=0.1)
+                yield conn
+
+        with patch.object(
+            QueueConsumer, 'establish_connection', new=establish_connection
+        ):
+            yield
+
+    @pytest.yield_fixture
+    def toxic_queue_consumer(self, toxiproxy):
+        with patch.object(QueueConsumer, 'amqp_uri', new=toxiproxy.uri):
+            yield
+
+    @pytest.yield_fixture
+    def service_rpc(self, rabbit_config):
+        with ServiceRpcProxy('service', rabbit_config) as proxy:
+            yield proxy
+
+    @pytest.fixture(autouse=True)
+    def container(
+        self, container_factory, rabbit_config, toxic_queue_consumer
+    ):
+
+        class Service(object):
+            name = "service"
+
+            @rpc
+            def echo(self, arg):
+                return arg
+
+        # very fast heartbeat
+        config = rabbit_config
+        config[HEARTBEAT_CONFIG_KEY] = 2  # seconds
+
+        container = container_factory(Service, config)
+        container.start()
+
+        return container
+
+    def test_normal(self, container, service_rpc):
+        assert service_rpc.echo("foo") == "foo"
+
+    def test_down(self, container, service_rpc, toxiproxy):
+        """ Verify we detect and recover from closed sockets.
+
+        This failure mode closes the socket between the consumer and the
+        rabbit broker.
+
+        Attempting to read from the closed socket raises a socket.error
+        and the connection is re-established.
+        """
+        queue_consumer = get_extension(container, QueueConsumer)
+
+        def reset(args, kwargs, result, exc_info):
+            toxiproxy.reset()
+            return True
+
+        with patch_wait(queue_consumer, 'on_connection_error', callback=reset):
+            toxiproxy.disable()
+
+        # connection re-established
+        assert service_rpc.echo("foo") == "foo"
+
+    def test_upstream_timeout(self, container, service_rpc, toxiproxy):
+        """ Verify we detect and recover from sockets timing out.
+
+        This failure mode means that the socket between the consumer and the
+        rabbit broker times for out `timeout` milliseconds and then closes.
+
+        Attempting to read from the socket after it's closed raises a
+        socket.error and the connection will be re-established. If `timeout`
+        is longer than twice the heartbeat interval, the behaviour is the same
+        as in `test_upstream_blackhole` below.
+        """
+        queue_consumer = get_extension(container, QueueConsumer)
+
+        def reset(args, kwargs, result, exc_info):
+            toxiproxy.reset_timeout()
+            return True
+
+        with patch_wait(queue_consumer, 'on_connection_error', callback=reset):
+            toxiproxy.set_timeout(timeout=100)
+
+        # connection re-established
+        assert service_rpc.echo("foo") == "foo"
+
+    def test_upstream_blackhole(self, container, service_rpc, toxiproxy):
+        """ Verify we detect and recover from sockets losing data.
+
+        This failure mode means that all data sent from the consumer to the
+        rabbit broker is lost, but the socket remains open.
+
+        Heartbeats sent from the consumer are not received by the broker. After
+        two beats are missed the broker closes the connection, and subsequent
+        reads from the socket raise a socket.error, so the connection is
+        re-established.
+        """
+        queue_consumer = get_extension(container, QueueConsumer)
+
+        def reset(args, kwargs, result, exc_info):
+            toxiproxy.reset_timeout()
+            return True
+
+        with patch_wait(queue_consumer, 'on_connection_error', callback=reset):
+            toxiproxy.set_timeout(timeout=0)
+
+        # connection re-established
+        assert service_rpc.echo("foo") == "foo"
+
+    def test_downstream_timeout(self, container, service_rpc, toxiproxy):
+        """ Verify we detect and recover from sockets timing out.
+
+        This failure mode means that the socket between the rabbit broker and
+        the consumer times for out `timeout` milliseconds and then closes.
+
+        Attempting to read from the socket after it's closed raises a
+        socket.error and the connection will be re-established. If `timeout`
+        is longer than twice the heartbeat interval, the behaviour is the same
+        as in `test_downstream_blackhole` below, except that the consumer
+        cancel will eventually (`timeout` milliseconds) raise a socket.error,
+        which is ignored, allowing the teardown to continue.
+
+        See :meth:`kombu.messsaging.Consumer.__exit__`
+        """
+        queue_consumer = get_extension(container, QueueConsumer)
+
+        def reset(args, kwargs, result, exc_info):
+            toxiproxy.reset_timeout()
+            return True
+
+        with patch_wait(queue_consumer, 'on_connection_error', callback=reset):
+            toxiproxy.set_timeout(stream="downstream", timeout=100)
+
+        # connection re-established
+        assert service_rpc.echo("foo") == "foo"
+
+    def test_downstream_blackhole(
+        self, container, service_rpc, toxiproxy
+    ):  # pragma: no cover
+        """ Verify we detect and recover from sockets losing data.
+
+        This failure mode means that all data sent from the rabbit broker to
+        the consumer is lost, but the socket remains open.
+
+        Heartbeat acknowledgements from the broker are not received by the
+        consumer. After two beats are missed the consumer raises a "too many
+        heartbeats missed" error.
+
+        Cancelling the consumer requests an acknowledgement from the broker,
+        which is swallowed by the socket. There is no timeout when reading
+        the acknowledgement so this hangs forever.
+
+        See :meth:`kombu.messsaging.Consumer.__exit__`
+        """
+        pytest.skip("skip until kombu supports recovery in this scenario")
+
+        queue_consumer = get_extension(container, QueueConsumer)
+
+        def reset(args, kwargs, result, exc_info):
+            toxiproxy.reset_timeout()
+            return True
+
+        with patch_wait(queue_consumer, 'on_connection_error', callback=reset):
+            toxiproxy.set_timeout(stream="downstream", timeout=0)
+
+        # connection re-established
+        assert service_rpc.echo("foo") == "foo"
+
+
+class TestReplyListenerDisconnections(object):
+    pass
 
 
 @skip_if_no_toxiproxy


### PR DESCRIPTION
Fix for #511.

Includes some commits cherry-picked from #504:

f5901f3a1d80fdaea8bf4cb16fd1ff8541fd6a86: standard toxiproxy tests for RpcConsumer
8841dd1464b56906e0d28c967ac58644daaeb381 and 891a91c94fb20e4328cf6a31765f3f8982d1e823: fix for hanging toxiproxy process