### PR TITLE
add recursive env var to config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,9 @@ matrix:
       python: 2.7
       env: TOX_ENV=py27-latest-lib
     - stage: test
+      python: 2.7
+      env: TOX_ENV=py27-extra-lib
+    - stage: test
       python: 3.4
       env: TOX_ENV=py34-oldest-lib
     - stage: test
@@ -79,6 +82,9 @@ matrix:
     - stage: test
       python: 3.6
       env: TOX_ENV=py36-latest-lib
+    - stage: test
+      python: 3.6
+      env: TOX_ENV=py36-extra-lib
     - stage: deploy
       script: skip
       deploy:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -51,9 +51,9 @@ Config values can be read via the built-in :ref:`config_dependency_provider` dep
 Environment variable substitution
 ---------------------------------
 YAML configuration files have support for environment variables.
-You can use bash style syntax: ``${ENV_VAR}``
-Optionally you can provide default values ``${ENV_VAR:default_value}``
-default values can contains environment variables recursively ``${ENV_VAR:default_${OTHER_ENV_VAR:value}}`` (note: this feature require regex package)
+You can use bash style syntax: ``${ENV_VAR}``.
+Optionally you can provide default values ``${ENV_VAR:default_value}``.
+Default values can contains environment variables recursively ``${ENV_VAR:default_${OTHER_ENV_VAR:value}}`` (note: this feature require regex package).
 
 
 .. code-block:: yaml
@@ -78,8 +78,8 @@ You can provide many level of generic default value
 
 .. code-block:: yaml
 
-	# foobar.yaml
-	AMQP_URI: ${AMQP_URI:pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}}
+    # foobar.yaml
+    AMQP_URI: ${AMQP_URI:pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}}
 
 this config accept AMQP_URI as environment variable, in this case RABBITMQ_* variables will not be used.
 
@@ -99,8 +99,8 @@ the parser for environment variable will pair all bracket.
 
 .. code-block::  yaml
 
-	# foobar.yaml
-	LANDING_URL_TEMPLATE: ${LANDING_URL_TEMPLATE:https://example.com/{path}}
+    # foobar.yaml
+    LANDING_URL_TEMPLATE: ${LANDING_URL_TEMPLATE:https://example.com/{path}}
 
 so the default value for this config will be https://example.com/{path}
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -81,7 +81,7 @@ You can provide many level of generic default value
 	# foobar.yaml
 	AMQP_URI: ${AMQP_URI:pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}}
 
-this config accept AMQP_URI as environment variable, in this case RABBITMQ_* env will not be used.
+this config accept AMQP_URI as environment variable, in this case RABBITMQ_* variables will not be used.
 
 The environment variable value is interpreted as YAML, so it is possible to use rich types:
 
@@ -95,7 +95,7 @@ The environment variable value is interpreted as YAML, so it is possible to use 
 
     $ A_LIST_OF_THINGS=[A,B,C] nameko run --config ./foobar.yaml <module>[:<ServiceClass>]
 
-the parser for environment variable will paire all braquet.
+the parser for environment variable will pair all bracket.
 
 .. code-block::  yaml
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -53,7 +53,7 @@ Environment variable substitution
 YAML configuration files have support for environment variables.
 You can use bash style syntax: ``${ENV_VAR}``.
 Optionally you can provide default values ``${ENV_VAR:default_value}``.
-Default values can contains environment variables recursively ``${ENV_VAR:default_${OTHER_ENV_VAR:value}}`` (note: this feature require regex package).
+Default values can contains environment variables recursively ``${ENV_VAR:default_${OTHER_ENV_VAR:value}}`` (note: this feature requires regex package).
 
 
 .. code-block:: yaml
@@ -74,14 +74,14 @@ If you need to quote the values in your YAML file, the explicit ``!env_var`` res
     # foobar.yaml
     AMQP_URI: !env_var "pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}"
 
-You can provide many level of generic default value
+You can provide many levels of default values
 
 .. code-block:: yaml
 
     # foobar.yaml
     AMQP_URI: ${AMQP_URI:pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}}
 
-this config accept AMQP_URI as environment variable, in this case RABBITMQ_* variables will not be used.
+this config accepts AMQP_URI as an environment variable, if provided RABBITMQ_* nested variables will not be used.
 
 The environment variable value is interpreted as YAML, so it is possible to use rich types:
 
@@ -95,7 +95,7 @@ The environment variable value is interpreted as YAML, so it is possible to use 
 
     $ A_LIST_OF_THINGS=[A,B,C] nameko run --config ./foobar.yaml <module>[:<ServiceClass>]
 
-the parser for environment variable will pair all bracket.
+the parser for environment variables will pair all brackets.
 
 .. code-block::  yaml
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -50,9 +50,10 @@ Config values can be read via the built-in :ref:`config_dependency_provider` dep
 
 Environment variable substitution
 ---------------------------------
-YAML configuration files have basic support for environment variables.
+YAML configuration files have support for environment variables.
 You can use bash style syntax: ``${ENV_VAR}``
 Optionally you can provide default values ``${ENV_VAR:default_value}``
+default values can contains environment variables recursively ``${ENV_VAR:default_${OTHER_ENV_VAR:value}}`` (note: this feature require regex package)
 
 
 .. code-block:: yaml
@@ -73,6 +74,15 @@ If you need to quote the values in your YAML file, the explicit ``!env_var`` res
     # foobar.yaml
     AMQP_URI: !env_var "pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}"
 
+You can provide many level of generic default value
+
+.. code-block:: yaml
+
+	# foobar.yaml
+	AMQP_URI: ${AMQP_URI:pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}}
+
+this config accept AMQP_URI as environment variable, in this case RABBITMQ_* env will not be used.
+
 The environment variable value is interpreted as YAML, so it is possible to use rich types:
 
 .. code-block:: yaml
@@ -84,6 +94,15 @@ The environment variable value is interpreted as YAML, so it is possible to use 
 .. code-block:: shell
 
     $ A_LIST_OF_THINGS=[A,B,C] nameko run --config ./foobar.yaml <module>[:<ServiceClass>]
+
+the parser for environment variable will paire all braquet.
+
+.. code-block::  yaml
+
+	# foobar.yaml
+	LANDING_URL_TEMPLATE: ${LANDING_URL_TEMPLATE:https://example.com/{path}}
+
+so the default value for this config will be https://example.com/{path}
 
 Interacting with running services
 ---------------------------------

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -98,6 +98,7 @@ reconnected
 reconnecting
 reconnection
 redis
+regex
 refactor
 refactored
 refactors

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -114,6 +114,7 @@ serialized
 serializers
 serializes
 serializing
+setuptools
 shutdown
 specialization
 specialize

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -80,7 +80,7 @@ def _replace_env_var(match):
             default = ''
 
         value = default
-        while IMPLICIT_ENV_VAR_MATCHER.match(value):
+        while IMPLICIT_ENV_VAR_MATCHER.match(value):  # pragma: no cover
             value = ENV_VAR_MATCHER.sub(_replace_env_var, value)
     return value
 

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -13,7 +13,7 @@ from . import commands
 
 try:
     import regex
-except ImportError:  # pragma: no cover
+except ImportError:
     ENV_VAR_MATCHER = re.compile(
         r"""
             \$\{       # match characters `${` literally
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover
             \}         # match character `}` literally
         """, re.VERBOSE
     )
-else:
+else:  # pragma: no cover
     ENV_VAR_MATCHER = regex.compile(
         r"""
         \$\{                #  match ${

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -10,6 +10,7 @@ from nameko.exceptions import CommandError, ConfigurationError
 
 from . import commands
 
+
 try:
     import regex
 except ImportError:  # pragma: no cover
@@ -25,23 +26,23 @@ except ImportError:  # pragma: no cover
 else:
     ENV_VAR_MATCHER = regex.compile(
         r"""
-        \$\{                        #  match ${
-        (                           #  first capturing group: variable name
-            [^{}:\s]+               #  variable name without {,},: or spaces
+        \$\{                #  match ${
+        (                   #  first capturing group: variable name
+            [^{}:\s]+       #  variable name without {,},: or spaces
         )
-        (?:                         # non capturing optional group for value
-            :                       # match : 
-            (                       # 2nd capturing group: default value
-                (?:                 # non capturing group for OR
-                    [^{}]           # any non bracket 
-                |                   # OR
-                    \{              # literal {
-                    (?2)            # recursive 2nd capturing group aka ([^{}]|{(?2)})
-                    \}              # literal }
-                )*                  #
-            )                       
+        (?:                 # non capturing optional group for value
+            :               # match :
+            (               # 2nd capturing group: default value
+                (?:         # non capturing group for OR
+                    [^{}]   # any non bracket
+                |           # OR
+                    \{      # literal {
+                    (?2)    # recursive 2nd capturing group aka ([^{}]|{(?2)})
+                    \}      # literal }
+                )*          #
+            )
         )?
-        \}                          # end of macher }
+        \}                  # end of macher }
         """,
         regex.VERBOSE
     )
@@ -74,7 +75,9 @@ def _replace_env_var(match):
     if value is None:
         # expand default using other vars
         if default is None:
-            default = ''  # regex module return None instead of '' if engine didn't entered default capture group
+            # regex module return None instead of
+            #  '' if engine didn't entered default capture group
+            default = ''
 
         value = default
         while IMPLICIT_ENV_VAR_MATCHER.match(value):

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -12,7 +12,7 @@ from . import commands
 
 try:
     import regex
-except ImportError:
+except ImportError:  # pragma: no cover
     ENV_VAR_MATCHER = re.compile(
         r"""
             \$\{       # match characters `${` literally
@@ -23,7 +23,6 @@ except ImportError:
         """, re.VERBOSE
     )
 else:
-
     ENV_VAR_MATCHER = regex.compile(
         r"""
         \$\{                        #  match ${

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -13,7 +13,7 @@ from . import commands
 
 try:
     import regex
-except ImportError:
+except ImportError:  # pragma: no cover
     ENV_VAR_MATCHER = re.compile(
         r"""
             \$\{       # match characters `${` literally

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
             "nameko-sqlalchemy==0.0.1",
             "PyJWT==1.5.2",
             "moto==1.0.1",
-            "bcrypt==3.1.3"
+            "bcrypt==3.1.3",
+            "regex==2018.2.21"
         ]
     },
     entry_points={

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -13,7 +13,7 @@ from nameko.exceptions import CommandError, ConfigurationError
 
 try:
     import regex
-except ImportError:
+except ImportError:  # pragma: no cover
     has_regex_module = False
 else:  # pragma: no cover
     del regex
@@ -385,7 +385,9 @@ class TestConfigEnvironmentVariables(object):
     ])
     @pytest.mark.skipif(has_regex_module,
                         reason='default behavior if no regex module')
-    def test_unhandled_recurtion(self, yaml_config, env_vars, expected_config):
+    def test_unhandled_recurtion(
+            self, yaml_config, env_vars, expected_config
+    ):  # pragma: no cover
         setup_yaml_parser()
 
         with patch.dict('os.environ'):

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -385,7 +385,7 @@ class TestConfigEnvironmentVariables(object):
     ])
     @pytest.mark.skipif(has_regex_module,
                         reason='default behavior if no regex module')
-    def test_unhandled_recurtion(
+    def test_unhandled_recursion(
             self, yaml_config, env_vars, expected_config
     ):  # pragma: no cover
         setup_yaml_parser()

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -13,10 +13,11 @@ from nameko.exceptions import CommandError, ConfigurationError
 
 try:
     import regex
+except ImportError:
+    has_regex_module = False
+else:  # pragma: no cover
     del regex
     has_regex_module = True
-except ImportError:  # pragma: no cover
-    has_regex_module = False
 
 
 @pytest.yield_fixture(autouse=True)
@@ -109,7 +110,7 @@ class TestConfigEnvironmentParser(object):
     ])
     @pytest.mark.skipif(not has_regex_module,
                         reason='0 support for nested env without regex module')
-    def test_maching_recursive_with_regex(self, value, expected):
+    def test_maching_recursive_with_regex(self, value, expected):  # pragma: no cover
         res = ENV_VAR_MATCHER.findall(value)
         assert res == expected
 
@@ -343,7 +344,7 @@ class TestConfigEnvironmentVariables(object):
                         reason='0 support for nested env without regex module')
     def test_environment_vars_recursive_in_config(
             self, yaml_config, env_vars, expected_config
-    ):
+    ):  # pragma: no cover
         setup_yaml_parser()
 
         with patch.dict('os.environ'):

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -5,11 +5,15 @@ import pytest
 import yaml
 from mock import patch
 
-from nameko.cli.main import main, setup_parser, setup_yaml_parser, ENV_VAR_MATCHER
+from nameko.cli.main import (
+    ENV_VAR_MATCHER, main, setup_parser, setup_yaml_parser
+)
 from nameko.exceptions import CommandError, ConfigurationError
+
 
 try:
     import regex
+    del regex
     has_regex_module = True
 except ImportError:  # pragma: no cover
     has_regex_module = False
@@ -73,8 +77,8 @@ class TestConfigEnvironmentParser(object):
         ('${VAR_NAME:default}', [('VAR_NAME', 'default')]),
         # multiple match with default
         ('${VAR_NAME1:default1}_${VAR_NAME2:default2}', [
-                ('VAR_NAME1', 'default1'),
-                ('VAR_NAME2', 'default2'),
+            ('VAR_NAME1', 'default1'),
+            ('VAR_NAME2', 'default2'),
         ]),
     ])
     def test_maching_env_variable(self, value, expected):
@@ -83,22 +87,28 @@ class TestConfigEnvironmentParser(object):
 
     @pytest.mark.parametrize(('value', 'expected'), [
         # on var, with {} in default (as str.format accept)
-        ('${VAR_NAME:my-{pytemplate}-template}', [('VAR_NAME', 'my-{pytemplate}-template')]),
+        ('${VAR_NAME:my-{pytemplate}-template}', [
+            ('VAR_NAME', 'my-{pytemplate}-template')]),
         # var with var in default
-        ('${VAR_NAME:my-${OTHER_VAR}-template}', [('VAR_NAME', 'my-${OTHER_VAR}-template')]),
+        ('${VAR_NAME:my-${OTHER_VAR}-template}', [
+            ('VAR_NAME', 'my-${OTHER_VAR}-template')]),
         # recursive interpretation of last var
-        ('my-${OTHER_VAR}-template', [('OTHER_VAR', '')]),
+        ('my-${OTHER_VAR}-template', [
+            ('OTHER_VAR', '')]),
         # var with var in default in default
-        ('${VAR_NAME:my-${OTHER_VAR:1}-template}', [('VAR_NAME', 'my-${OTHER_VAR:1}-template')]),
+        ('${VAR_NAME:my-${OTHER_VAR:1}-template}', [
+            ('VAR_NAME', 'my-${OTHER_VAR:1}-template')]),
         # recursive interpretation of last var
-        ('my-${OTHER_VAR:1}-template', [('OTHER_VAR', '1')]),
+        ('my-${OTHER_VAR:1}-template', [
+            ('OTHER_VAR', '1')]),
         # multiple var in default
         ('${VAR_NAME1:default1}_${VAR_NAME2:default2}', [
-                ('VAR_NAME1', 'default1'),
-                ('VAR_NAME2', 'default2'),
+            ('VAR_NAME1', 'default1'),
+            ('VAR_NAME2', 'default2'),
         ]),
     ])
-    @pytest.mark.skipif(not has_regex_module, reason='no support for nested env without regex module')
+    @pytest.mark.skipif(not has_regex_module,
+                        reason='0 support for nested env without regex module')
     def test_maching_recursive_with_regex(self, value, expected):
         res = ENV_VAR_MATCHER.findall(value)
         assert res == expected
@@ -286,7 +296,6 @@ class TestConfigEnvironmentVariables(object):
             results = yaml.load(yaml_config)
             assert results == {'FOO': "${VAR1}", 'BAR': [1, 2, 3]}
 
-
     @pytest.mark.parametrize(('yaml_config', 'env_vars', 'expected_config'), [
         # recursive env with root value
         (
@@ -330,8 +339,11 @@ class TestConfigEnvironmentVariables(object):
             {"FOO": '{surname}'},
         ),
     ])
-    @pytest.mark.skipif(not has_regex_module, reason='no support for nested env without regex module')
-    def test_environment_vars_recursive_in_config(self, yaml_config, env_vars, expected_config):
+    @pytest.mark.skipif(not has_regex_module,
+                        reason='0 support for nested env without regex module')
+    def test_environment_vars_recursive_in_config(
+            self, yaml_config, env_vars, expected_config
+    ):
         setup_yaml_parser()
 
         with patch.dict('os.environ'):
@@ -340,4 +352,3 @@ class TestConfigEnvironmentVariables(object):
 
             results = yaml.load(yaml_config)
             assert results == expected_config
-

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -11,7 +11,7 @@ from nameko.exceptions import CommandError, ConfigurationError
 try:
     import regex
     has_regex_module = True
-except ImportError:
+except ImportError:  # pragma: no cover
     has_regex_module = False
 
 

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -110,7 +110,9 @@ class TestConfigEnvironmentParser(object):
     ])
     @pytest.mark.skipif(not has_regex_module,
                         reason='0 support for nested env without regex module')
-    def test_maching_recursive_with_regex(self, value, expected):  # pragma: no cover
+    def test_maching_recursive_with_regex(
+            self, value, expected
+    ):  # pragma: no cover
         res = ENV_VAR_MATCHER.findall(value)
         assert res == expected
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,16 @@ deps =
     pinned: six==1.10.0
     pinned: werkzeug==0.11.11
     pinned: wrapt==1.10.8
-    pinned: regex==2018.2.21
+
+    extra: eventlet==0.20.0
+    extra: kombu==3.0.37
+    extra: mock==2.0.0
+    extra: path.py==9.0
+    extra: requests==2.12.3
+    extra: six==1.10.0
+    extra: werkzeug==0.11.11
+    extra: wrapt==1.10.8
+    extra: regex==2018.2.21
 
     # we can't test eventlet>0.20.1 in our py27 CI environment until the fix
     # in https://github.com/eventlet/eventlet/issues/401 is released

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-{oldest,pinned,latest}-lib, {py27,py34,py35,py36}-mastereventlet, py36-branchcoverage-lib, {py27,py36}-examples, docs, {py27,py36}-static
+envlist = {py27,py34,py35,py36}-{oldest,pinned,latest,extra}-lib, {py27,py34,py35,py36}-mastereventlet, py36-branchcoverage-lib, {py27,py36}-examples, docs, {py27,py36}-static
 skipsdist = True
 
 [testenv]
@@ -23,6 +23,7 @@ deps =
     pinned: six==1.10.0
     pinned: werkzeug==0.11.11
     pinned: wrapt==1.10.8
+    pinned: regex==2018.2.21
 
     # we can't test eventlet>0.20.1 in our py27 CI environment until the fix
     # in https://github.com/eventlet/eventlet/issues/401 is released


### PR DESCRIPTION
imprements the nested resolution of env var in yaml config.

this changes is related to issue #510


it add the feature to parse correctly default value in environment values. 

the feature require extra package __regex__ to accept the recursive (?2) in the regex.

the new behavior is enabled only if this package is installed. if not, the old non recursive regex is used.