### PR TITLE
[WIP] Global nameko config

### DIFF
--- a/nameko/__init__.py
+++ b/nameko/__init__.py
@@ -1,0 +1,28 @@
+config = {}
+"""
+It is possible to set the config by using ``--config`` switch of Nameko
+command line interface.
+
+The config can be used straight on service definition level, e.g.::
+
+    from nameko import config
+    from nameko.messaging import Consumer, Queue
+
+    class Service:
+
+        @consume(
+            queue=Queue(
+                exchange=config.MY_EXCHANGE,
+                routing_key=config.MY_ROUTING_KEY,
+                name=config.MY_QUEUE_NAME
+            ),
+            prefetch_count=config.MY_CONSUMER_PREFETCH_COUNT
+        )
+        def consume(self, payload):
+            pass
+
+As a plain dictionary it is normally mutable at any point. After all,
+we're all consenting adults here.)
+
+TODO Maybe add some immutability instead of using a plain dict?
+"""

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -7,6 +7,7 @@ import re
 import yaml
 
 from nameko.exceptions import CommandError, ConfigurationError
+from nameko import config
 
 from . import commands
 
@@ -58,10 +59,21 @@ def setup_yaml_parser():
     yaml.add_implicit_resolver('!env_var', IMPLICIT_ENV_VAR_MATCHER)
 
 
+def load_config(config_path):
+    with open(config_path) as fle:
+        return yaml.load(fle)
+
+
+def setup_config(config_path):
+    setup_yaml_parser()
+    if config_path:
+        config.update(load_config(config_path))
+
+
 def main():
     parser = setup_parser()
     args = parser.parse_args()
-    setup_yaml_parser()
+    setup_config(args.config)
     try:
         args.main(args)
     except (CommandError, ConfigurationError) as exc:

--- a/nameko/cli/run.py
+++ b/nameko/cli/run.py
@@ -13,9 +13,9 @@ import signal
 import sys
 
 import six
-import yaml
 from eventlet import backdoor
 
+from nameko import config
 from nameko.constants import AMQP_URI_CONFIG_KEY
 from nameko.exceptions import CommandError
 from nameko.extensions import ENTRYPOINT_EXTENSIONS_ATTR
@@ -160,13 +160,8 @@ def main(args):
     if '.' not in sys.path:
         sys.path.insert(0, '.')
 
-    if args.config:
-        with open(args.config) as fle:
-            config = yaml.load(fle)
-    else:
-        config = {
-            AMQP_URI_CONFIG_KEY: args.broker
-        }
+    if AMQP_URI_CONFIG_KEY not in config:
+        config.update({AMQP_URI_CONFIG_KEY: args.broker})
 
     if "LOGGING" in config:
         logging.config.dictConfig(config['LOGGING'])

--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -3,8 +3,7 @@ import os
 import sys
 from types import ModuleType
 
-import yaml
-
+from nameko import config
 from nameko.constants import AMQP_URI_CONFIG_KEY
 from nameko.standalone.events import event_dispatcher
 from nameko.standalone.rpc import ClusterRpcProxy
@@ -72,13 +71,11 @@ Usage:
 
 def main(args):
 
-    if args.config:
-        with open(args.config) as fle:
-            config = yaml.load(fle)
-        broker_from = " (from --config)"
-    else:
-        config = {AMQP_URI_CONFIG_KEY: args.broker}
+    if AMQP_URI_CONFIG_KEY not in config:
+        config.update({AMQP_URI_CONFIG_KEY: args.broker})
         broker_from = ""
+    else:
+        broker_from = " (from --config)"
 
     banner = 'Nameko Python %s shell on %s\nBroker: %s%s' % (
         sys.version,

--- a/nameko/cli/show_config.py
+++ b/nameko/cli/show_config.py
@@ -2,10 +2,8 @@ from __future__ import print_function
 
 import yaml
 
+from nameko import config
+
 
 def main(args):
-
-    with open(args.config) as fle:
-        config = yaml.load(fle)
-
     print(yaml.dump(config, default_flow_style=False))

--- a/test/cli/conftest.py
+++ b/test/cli/conftest.py
@@ -1,0 +1,18 @@
+import sys
+
+import pytest
+from mock import patch
+
+from nameko.cli.main import main
+from nameko import config
+
+
+@pytest.fixture
+def command():
+    config.clear()
+
+    def _command(*argv):
+        with patch.object(sys, 'argv', argv):
+            main()
+
+    return _command

--- a/test/cli/test_show_config.py
+++ b/test/cli/test_show_config.py
@@ -2,12 +2,9 @@ from textwrap import dedent
 
 from mock import patch
 
-from nameko.cli.commands import ShowConfig
-from nameko.cli.main import setup_parser, setup_yaml_parser
-
 
 @patch('nameko.cli.main.os')
-def test_main(mock_os, tmpdir, capsys):
+def test_main(mock_os, tmpdir, capsys, command):
 
     config = tmpdir.join('config.yaml')
     config.write("""
@@ -15,19 +12,15 @@ def test_main(mock_os, tmpdir, capsys):
         BAR: ${BAR}
     """)
 
-    parser = setup_parser()
-    setup_yaml_parser()
-    args = parser.parse_args([
-        'show-config',
-        '--config',
-        config.strpath,
-    ])
-
     mock_os.environ = {
         'BAR': '[1,2,3]'
     }
 
-    ShowConfig.main(args)
+    command(
+        'nameko', 'show-config',
+        '--config', config.strpath,
+    )
+
     out, _ = capsys.readouterr()
 
     expected = dedent("""


### PR DESCRIPTION
A draft of config made accessible outside container and workers - also in the service
definition, e.g.:

```python

from nameko.messaging import Consumer
from nameko import config

class Service:

    @consume(
        queue=Queue(
            exchange=config.MY_EXCHANGE,
            routing_key=config.MY_ROUTING_KEY,
            name=config.MY_QUEUE_NAME
        ),
        prefetch_count=config.MY_CONSUMER_PREFETCH_COUNT
    )
    def consume(self, payload):
        pass
```

It will also help with setting optionals by simply passing them to the constructor:
```python
from nameko import config
from nameko_sqlalchemy import Database

class Service:
    db = Database(engine_options=config.DB_ENGINE_OPTIONS)
```

Extensions could load from config only entries necessary for them to run (for example in the Database case it would be the DB connection). Anything optional can be passed on instantiation using settings laded from config. Also this way users are free to structure configs their way.