### PR TITLE
workaround for https://github.com/celery/kombu/issues/838

### DIFF
--- a/nameko/cli/run.py
+++ b/nameko/cli/run.py
@@ -100,6 +100,8 @@ def setup_backdoor(runner, port):
             'This would kill your service, not close the backdoor. To exit, '
             'use ctrl-c.')
     socket = eventlet.listen(('localhost', port))
+    # work around https://github.com/celery/kombu/issues/838
+    socket.settimeout(None)
     gt = eventlet.spawn(
         backdoor.backdoor_server,
         socket,

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -83,15 +83,10 @@ def rabbit_manager(request):
 
 @pytest.yield_fixture(scope='session')
 def vhost_pipeline(request, rabbit_manager):
-    from collections import Iterable
     from six.moves.urllib.parse import urlparse  # pylint: disable=E0401
     import random
-    import socket
     import string
-    from kombu.pools import connections
     from nameko.testing.utils import ResourcePipeline
-    from nameko.utils.retry import retry
-    from requests.exceptions import HTTPError
 
     rabbit_amqp_uri = request.config.getoption('RABBIT_AMQP_URI')
     uri_parts = urlparse(rabbit_amqp_uri)
@@ -107,17 +102,8 @@ def vhost_pipeline(request, rabbit_manager):
         )
         return vhost
 
-    @retry(for_exceptions=(HTTPError, socket.timeout), delay=1, max_attempts=9)
     def destroy(vhost):
         rabbit_manager.delete_vhost(vhost)
-
-        # make sure connections for this vhost are also destroyed.
-        vhost_pools = [
-            pool for key, pool in list(connections.items())
-            if isinstance(key, Iterable) and key[4] == vhost
-        ]
-        for pool in vhost_pools:
-            pool.force_close_all()
 
     pipeline = ResourcePipeline(create, destroy)
 

--- a/nameko/web/server.py
+++ b/nameko/web/server.py
@@ -97,6 +97,8 @@ class WebServer(ProviderCollector, SharedExtension):
         if not self._starting:
             self._starting = True
             self._sock = eventlet.listen(self.bind_addr)
+            # work around https://github.com/celery/kombu/issues/838
+            self._sock.settimeout(None)
             self._serv = self.get_wsgi_server(self._sock, self.get_wsgi_app())
             self._gt = self.container.spawn_managed_thread(self.run)
 


### PR DESCRIPTION
If we don't explicitly set the timeout we may inherit the temporary default.

This can cause failures when testing services that use AMQP and HTTP entrypoints with the builtin pytest helpers. The line at https://github.com/nameko/nameko/blob/master/nameko/testing/pytest.py#L120 can execute while a new service is starting, triggering the bug, and the listening socket only waits 0.1s for a connection.