### PR TITLE
Log unhandled worker exceptions at ERROR level

### DIFF
--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -390,7 +390,13 @@ class ServiceContainer(object):
                 with _log_time('ran handler for %s', worker_ctx):
                     result = method(*worker_ctx.args, **worker_ctx.kwargs)
             except Exception as exc:
-                _log.exception('error handling worker %s: %s', worker_ctx, exc)
+                if isinstance(exc, worker_ctx.entrypoint.expected_exceptions):
+                    _log.info(
+                        '(expected) error handling worker %s: %s',
+                        worker_ctx, exc, exc_info=True)
+                else:
+                    _log.exception(
+                        'error handling worker %s: %s', worker_ctx, exc)
                 exc_info = sys.exc_info()
 
             if handle_result is not None:

--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -390,8 +390,7 @@ class ServiceContainer(object):
                 with _log_time('ran handler for %s', worker_ctx):
                     result = method(*worker_ctx.args, **worker_ctx.kwargs)
             except Exception as exc:
-                _log.info('error handling worker %s: %s', worker_ctx, exc,
-                          exc_info=True)
+                _log.exception('error handling worker %s: %s', worker_ctx, exc)
                 exc_info = sys.exc_info()
 
             if handle_result is not None:

--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -391,7 +391,7 @@ class ServiceContainer(object):
                     result = method(*worker_ctx.args, **worker_ctx.kwargs)
             except Exception as exc:
                 if isinstance(exc, worker_ctx.entrypoint.expected_exceptions):
-                    _log.info(
+                    _log.warning(
                         '(expected) error handling worker %s: %s',
                         worker_ctx, exc, exc_info=True)
                 else:

--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -480,7 +480,7 @@ class ServiceContainer(object):
             _log.debug('%s thread killed by container', self)
 
         except Exception:
-            _log.error('%s thread exited with error', self, exc_info=True)
+            _log.critical('%s thread exited with error', self, exc_info=True)
             # any uncaught error in a thread is unexpected behavior
             # and probably a bug in the extension or container.
             # to be safe we call self.kill() to kill our dependencies and

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -56,6 +56,7 @@ class CallCollectorMixin(object):
 
 class CallCollectingEntrypoint(CallCollectorMixin, Entrypoint):
     instances = set()
+    expected_exceptions = ()
 
 
 class CallCollectingDependencyProvider(CallCollectorMixin, DependencyProvider):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -29,6 +29,10 @@ class ExampleService(object):
     def broken(self):
         raise ExampleError("broken")
 
+    @rpc(expected_exceptions=ExampleError)
+    def bad(self):
+        raise ExampleError("bad")
+
     @rpc
     def proxy(self, method, *args):
         """ Proxies RPC calls to ``method`` on itself, so we can test handling
@@ -58,6 +62,21 @@ def test_error_in_worker(container_factory, rabbit_config):
 
     assert logger.exception.call_args == call(
         'error handling worker %s: %s', ANY, ANY)
+
+
+def test_exppected_error_in_worker(container_factory, rabbit_config):
+
+    container = container_factory(ExampleService, rabbit_config)
+    container.start()
+
+    with patch('nameko.containers._log') as logger:
+        with entrypoint_hook(container, "bad") as bad:
+            with pytest.raises(ExampleError):
+                bad()
+    assert not container._died.ready()
+
+    assert logger.info.call_args == call(
+        '(expected) error handling worker %s: %s', ANY, ANY, exc_info=True)
 
 
 def test_error_in_remote_worker(container_factory, rabbit_config):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,7 +1,7 @@
 # start a runner with a service that errors. does it hang? or stop?
 # how do we get an individual servicecontainer to blow up?
 import pytest
-from mock import patch
+from mock import ANY, patch, call
 
 from nameko.events import EventDispatcher
 from nameko.exceptions import RemoteError
@@ -50,10 +50,14 @@ def test_error_in_worker(container_factory, rabbit_config):
     container = container_factory(ExampleService, rabbit_config)
     container.start()
 
-    with entrypoint_hook(container, "broken") as broken:
-        with pytest.raises(ExampleError):
-            broken()
+    with patch('nameko.containers._log') as logger:
+        with entrypoint_hook(container, "broken") as broken:
+            with pytest.raises(ExampleError):
+                broken()
     assert not container._died.ready()
+
+    assert logger.exception.call_args == call(
+        'error handling worker %s: %s', ANY, ANY)
 
 
 def test_error_in_remote_worker(container_factory, rabbit_config):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,7 +1,7 @@
 # start a runner with a service that errors. does it hang? or stop?
 # how do we get an individual servicecontainer to blow up?
 import pytest
-from mock import ANY, patch, call
+from mock import ANY, call, patch
 
 from nameko.events import EventDispatcher
 from nameko.exceptions import RemoteError

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -64,7 +64,7 @@ def test_error_in_worker(container_factory, rabbit_config):
         'error handling worker %s: %s', ANY, ANY)
 
 
-def test_exppected_error_in_worker(container_factory, rabbit_config):
+def test_expected_error_in_worker(container_factory, rabbit_config):
 
     container = container_factory(ExampleService, rabbit_config)
     container.start()
@@ -75,7 +75,7 @@ def test_exppected_error_in_worker(container_factory, rabbit_config):
                 bad()
     assert not container._died.ready()
 
-    assert logger.info.call_args == call(
+    assert logger.warning.call_args == call(
         '(expected) error handling worker %s: %s', ANY, ANY, exc_info=True)
 
 


### PR DESCRIPTION
It's a bit confusing when unhandled worker exceptions are logged at INFO level. Any filtering for more serious log level then sort of hides entrypoint failures. This PR changes the level to ERROR.