### PR TITLE
Adding a new env var constructor for config.yml

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -74,6 +74,16 @@ If you need to quote the values in your YAML file, the explicit ``!env_var`` res
     # foobar.yaml
     AMQP_URI: !env_var "pyamqp://${RABBITMQ_USER:guest}:${RABBITMQ_PASSWORD:password}@${RABBITMQ_HOST:localhost}"
 
+If you need to use values as raw strings in your YAML file without them getting converted to native python,
+the explicit ``!raw_env_var`` resolver is required:
+
+.. code-block:: yaml
+
+    # foobar.yaml
+    ENV_THAT_IS_NEEDED_RAW: !raw_env_var "${ENV_THAT_IS_NEEDED_RAW:1234.5660}"
+
+This will turn into the string value ``1234.5660``, instead of a float number.
+
 You can provide many levels of default values
 
 .. code-block:: yaml

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -94,7 +94,8 @@ def env_var_constructor(loader, node, raw=False):
 
 def setup_yaml_parser():
     yaml.add_constructor('!env_var', env_var_constructor)
-    yaml.add_constructor('!raw_env_var', partial(env_var_constructor, raw=True))
+    yaml.add_constructor('!raw_env_var',
+                         partial(env_var_constructor, raw=True))
     yaml.add_implicit_resolver('!env_var', IMPLICIT_ENV_VAR_MATCHER)
 
 

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import argparse
 import os
 import re
+from functools import partial
 
 import yaml
 
@@ -85,14 +86,15 @@ def _replace_env_var(match):
     return value
 
 
-def env_var_constructor(loader, node):
+def env_var_constructor(loader, node, raw=False):
     raw_value = loader.construct_scalar(node)
     value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
-    return yaml.safe_load(value)
+    return value if raw else yaml.safe_load(value)
 
 
 def setup_yaml_parser():
     yaml.add_constructor('!env_var', env_var_constructor)
+    yaml.add_constructor('!raw_env_var', partial(env_var_constructor, raw=True))
     yaml.add_implicit_resolver('!env_var', IMPLICIT_ENV_VAR_MATCHER)
 
 

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -171,6 +171,40 @@ class TestConfigEnvironmentVariables(object):
             {'INT': '1', 'FLOAT': '1.1', 'BOOL': 'True'},
             {'FOO': [{'BAR': 1}, {'BAR': 1.1}, {'BAR': True}]}
         ),
+        # quoted default results in string
+        (
+            """
+            FOO:
+                - BAR: ${INT:"1"}
+                - BAR: ${FLOAT:"1.1"}
+                - BAR: ${BOOL:"True"}
+            """,
+            {}, {'FOO': [{'BAR': "1"}, {'BAR': "1.1"}, {'BAR': "True"}]}
+        ),
+        # quoted value results in string
+        # double-quote required
+        (
+            """
+            FOO:
+                - BAR: !env_var "'${INT}'"
+                - BAR: !env_var "'${FLOAT}'"
+                - BAR: !env_var "'${BOOL}'"
+            """,
+            {'INT': '1', 'FLOAT': '1.1', 'BOOL': 'True'},
+            {'FOO': [{'BAR': "1"}, {'BAR': "1.1"}, {'BAR': "True"}]}
+        ),
+        # quoted input results in string
+        # double-quote required
+        (
+            """
+            FOO:
+                - BAR: ${INT}
+                - BAR: ${FLOAT}
+                - BAR: ${BOOL}
+            """,
+            {'INT': '"1"', 'FLOAT': '"1.1"', 'BOOL': '"True"'},
+            {'FOO': [{'BAR': "1"}, {'BAR': "1.1"}, {'BAR': "True"}]}
+        ),
         # list of scalar values
         (
             """

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -141,6 +141,8 @@ class TestConfigEnvironmentVariables(object):
         ('FOO: "${BAR:foo}"', {'BAR': 'bar'}, {'FOO': '${BAR:foo}'}),
         # quoted values work only with explicit resolver
         ('FOO: !env_var "${BAR:foo}"', {'BAR': 'bar'}, {'FOO': 'bar'}),
+        # quoted values with raw_env_var constructor to avoid yaml parsing
+        ('FOO: !raw_env_var "${BAR}"', {'BAR': '123.0'}, {'FOO': '123.0'}),
         # $ sign can be used
         ('FOO: $bar', {}, {'FOO': '$bar'}),
         # multiple substitutions


### PR DESCRIPTION
## The problem:

If I need to use an env var value like the following:
`142336939733.280047291474`

The current config parser does some parsing and interprets it as a float, which ultimately makes it to my container config like this:
`142336939733.28006`

## The solution

To avoid it, I introduce a new constructor that skips the use of `yaml.safe_load` on the value:
```yaml
    # foobar.yaml
    ENV_THAT_IS_NEEDED_RAW: !raw_env_var "${ENV_THAT_IS_NEEDED_RAW:1234.5660}"
```

This will turn into the string value `1234.5660`, instead of a float number. 