### PR TITLE
Include new custom headers in messaging.publish

### DIFF
--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -174,9 +174,9 @@ class Publisher(DependencyProvider, HeaderEncoder):
         )
 
     def get_dependency(self, worker_ctx):
-        extra_headers = self.get_message_headers(worker_ctx)
 
         def publish(msg, **kwargs):
+            extra_headers = self.get_message_headers(worker_ctx)
             self.publisher.publish(
                 msg, extra_headers=extra_headers, **kwargs
             )

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -247,6 +247,41 @@ def test_publish_custom_headers(
     ]
 
 
+@pytest.mark.usefixtures("predictable_call_ids")
+def test_publish_custom_headers_added_in_current_request(
+    mock_container, mock_producer, rabbit_config
+):
+    container = mock_container
+    container.config = rabbit_config
+    container.service_name = "srcservice"
+
+    ctx_data = {'language': 'en', 'customheader1': 'customvalue1'}
+    service = Mock()
+    worker_ctx = WorkerContext(
+        container, service, DummyProvider('method'), data=ctx_data
+    )
+
+    publisher = Publisher(queue=foobar_queue).bind(container, "publish")
+    publisher.setup()
+
+    # test publish
+    msg = "msg"
+    headers = {'nameko.language': 'en',
+               'nameko.customheader1': 'customvalue1',
+               'nameko.customheader2': 'customvalue2',
+               'nameko.call_id_stack': ['srcservice.method.0']}
+    service.publish = publisher.get_dependency(worker_ctx)
+
+    # Simulate adding an additional custom header in the current request,
+    # by changing worker-context after `get_dependency` is called.
+    worker_ctx.data['customheader2'] = 'customvalue2'
+
+    service.publish(msg, publish_kwarg="value")
+
+    _, call_kwargs = mock_producer.publish.call_args
+    assert call_kwargs['headers'] == headers
+
+
 def test_header_encoder(empty_config):
 
     context_data = {


### PR DESCRIPTION
Fixes a problem where additional custom headers are not propagated via a messaging Publish call.

Only headers present at the start of the worker-request were previously propagated.