### PR TITLE
get result's exchange from incoming message (or eventualy from config file).

### DIFF
--- a/nameko/rpc.py
+++ b/nameko/rpc.py
@@ -123,7 +123,7 @@ class RpcConsumer(SharedExtension, ProviderCollector):
         serializer = self.container.config.get(
             SERIALIZER_CONFIG_KEY, DEFAULT_SERIALIZER
         )
-        exchange = get_rpc_exchange(self.container.config)
+        exchange = message.delivery_info.get('exchange', get_rpc_exchange(self.container.config))
         ssl = self.container.config.get(AMQP_SSL_CONFIG_KEY)
 
         responder = Responder(amqp_uri, exchange, serializer, message, ssl=ssl)


### PR DESCRIPTION
This will allow to respond to messages coming from "parent" exchange of an alternate exchange processing the message.

For example, if you have multiple people working on a project, each one can have it's own exchange where they run the services they are working on, and all these exchanges can have the same alternate exchange where you can run the "common" services. So each programmer does not need to run all the services of a project. 