### PR TITLE
Add ClusterRpc DependencyProvider

### DIFF
--- a/docs/built_in_extensions.rst
+++ b/docs/built_in_extensions.rst
@@ -8,7 +8,7 @@ Nameko includes a number of built-in :ref:`extensions <extensions>`. This sectio
 RPC
 ---
 
-Nameko includes an implementation of RPC over AMQP. It comprises the ``@rpc`` entrypoint, a proxy for services to talk to other services, and a standalone proxy that non-Nameko clients can use to make RPC calls to a cluster:
+Nameko includes an implementation of RPC over AMQP. It comprises the ``@rpc`` entrypoint, a client for services to talk to other services, and a standalone client that non-Nameko clients can use to make RPC calls to a cluster:
 
 .. literalinclude:: examples/rpc.py
 

--- a/docs/community_extensions.rst
+++ b/docs/community_extensions.rst
@@ -53,7 +53,7 @@ Extensions
     * `nameko-sendgrid <https://github.com/invictuscapital/nameko-sendgrid>`_
 
         SendGrid dependency for nameko, for sending transactional and marketing emails.
-        
+
     * `nameko-cachetools <https://github.com/santiycr/nameko-cachetools>`_
 
         Tools to cache RPC interactions between your nameko services.
@@ -71,7 +71,7 @@ Supplementary Libraries
 
     * `nameko-proxy <https://github.com/fraglab/nameko-proxy>`_
 
-        Standalone async proxy to communicate with Nameko microservices.
+        Standalone async client to communicate with Nameko microservices.
 
 Search PyPi for more `nameko packages <https://pypi.python.org/pypi?%3Aaction=search&term=nameko&submit=search>`_
 

--- a/docs/examples/anatomy.py
+++ b/docs/examples/anatomy.py
@@ -1,10 +1,11 @@
-from nameko.rpc import rpc, RpcProxy
+from nameko.rpc import ServiceRpc, rpc
+
 
 class Service:
     name = "service"
 
     # we depend on the RPC interface of "another_service"
-    other_rpc = RpcProxy("another_service")
+    other_rpc = ServiceRpc("another_service")
 
     @rpc  # `method` is exposed over RPC
     def method(self):

--- a/docs/examples/async_rpc.py
+++ b/docs/examples/async_rpc.py
@@ -1,4 +1,4 @@
-with ClusterRpcProxy(config) as cluster_rpc:
+with ClusterRpcClient(config) as cluster_rpc:
     hello_res = cluster_rpc.service_x.remote_method.call_async("hello")
     world_res = cluster_rpc.service_x.remote_method.call_async("world")
     # do work while waiting

--- a/docs/examples/rpc.py
+++ b/docs/examples/rpc.py
@@ -1,4 +1,5 @@
-from nameko.rpc import rpc, RpcProxy
+from nameko.rpc import ServiceRpc, rpc
+
 
 class ServiceY:
     name = "service_y"
@@ -11,7 +12,7 @@ class ServiceY:
 class ServiceX:
     name = "service_x"
 
-    y = RpcProxy("service_y")
+    y = ServiceRpc("service_y")
 
     @rpc
     def remote_method(self, value):

--- a/docs/examples/standalone_rpc.py
+++ b/docs/examples/standalone_rpc.py
@@ -1,8 +1,9 @@
-from nameko.standalone.rpc import ClusterRpcProxy
+from nameko.standalone.rpc import ClusterRpcClient
+
 
 config = {
     'AMQP_URI': AMQP_URI  # e.g. "pyamqp://guest:guest@localhost"
 }
 
-with ClusterRpcProxy(config) as cluster_rpc:
+with ClusterRpcClient(config) as cluster_rpc:
     cluster_rpc.service_x.remote_method("hellø")  # "hellø-x-y"

--- a/docs/examples/test/test_examples.py
+++ b/docs/examples/test/test_examples.py
@@ -453,18 +453,18 @@ class TestExpectedExceptions:
 
         with ServiceRpcClient(
             "service", rabbit_config, context_data={"auth": token}
-        ) as proxy:
+        ) as client:
             with pytest.raises(RemoteError) as exc:
-                proxy.update(None)
+                client.update(None)
             assert exc.value.exc_type == 'Unauthorized'
 
         admin_token = jwt.encode({"roles": ['admin']}, key=JWT_SECRET)
 
         with ServiceRpcClient(
             "service", rabbit_config, context_data={"auth": admin_token}
-        ) as proxy:
+        ) as client:
             with pytest.raises(RemoteError) as exc:
-                proxy.update(None)
+                client.update(None)
             assert exc.value.exc_type == 'TypeError'
 
 
@@ -477,11 +477,11 @@ class TestSensitiveArguments:
         container = container_factory(Service, rabbit_config)
         container.start()
 
-        with ServiceRpcClient("service", rabbit_config) as proxy:
-            token = proxy.login("matt", "secret")
+        with ServiceRpcClient("service", rabbit_config) as client:
+            token = client.login("matt", "secret")
             jwt.decode(token, key=JWT_SECRET, verify=True)
             with pytest.raises(RemoteError) as exc:
-                proxy.login("matt", "incorrect")
+                client.login("matt", "incorrect")
             assert exc.value.exc_type == "Unauthenticated"
 
 

--- a/docs/examples/testing/integration_test.py
+++ b/docs/examples/testing/integration_test.py
@@ -1,9 +1,9 @@
 """ Service integration testing best practice.
 """
 
-from nameko.rpc import rpc, RpcProxy
-from nameko.testing.utils import get_container
+from nameko.rpc import ServiceRpc, rpc
 from nameko.testing.services import entrypoint_hook
+from nameko.testing.utils import get_container
 
 
 class ServiceX:
@@ -11,7 +11,7 @@ class ServiceX:
     """
     name = "service_x"
 
-    y = RpcProxy("service_y")
+    y = ServiceRpc("service_y")
 
     @rpc
     def remote_method(self, value):

--- a/docs/examples/testing/large_integration_test.py
+++ b/docs/examples/testing/large_integration_test.py
@@ -18,7 +18,7 @@ import pytest
 from nameko.events import EventDispatcher, event_handler
 from nameko.exceptions import RemoteError
 from nameko.extensions import DependencyProvider
-from nameko.rpc import RpcProxy, rpc
+from nameko.rpc import ServiceRpc, rpc
 from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import replace_dependencies, restrict_entrypoints
 from nameko.testing.utils import get_container
@@ -68,9 +68,9 @@ class AcmeShopService:
     name = "acmeshopservice"
 
     user_basket = ShoppingBasket()
-    stock_rpc = RpcProxy('stockservice')
-    invoice_rpc = RpcProxy('invoiceservice')
-    payment_rpc = RpcProxy('paymentservice')
+    stock_rpc = ServiceRpc('stockservice')
+    invoice_rpc = ServiceRpc('invoiceservice')
+    payment_rpc = ServiceRpc('paymentservice')
 
     fire_event = EventDispatcher()
 

--- a/docs/examples/testing/large_integration_test.py
+++ b/docs/examples/testing/large_integration_test.py
@@ -246,33 +246,33 @@ class PaymentService:
 
 
 @pytest.yield_fixture
-def rpc_proxy_factory(rabbit_config):
-    """ Factory fixture for standalone RPC proxies.
+def rpc_client_factory(rabbit_config):
+    """ Factory fixture for standalone RPC clients.
 
-    Proxies are started automatically so they can be used without a ``with``
-    statement. All created proxies are stopped at the end of the test, when
+    Clients are started automatically so they can be used without a ``with``
+    statement. All created clients are stopped at the end of the test, when
     this fixture closes.
     """
-    all_proxies = []
+    all_clients = []
 
-    def make_proxy(service_name, **kwargs):
-        proxy = ServiceRpcClient(service_name, rabbit_config, **kwargs)
-        all_proxies.append(proxy)
-        return proxy.start()
+    def make_client(service_name, **kwargs):
+        client = ServiceRpcClient(service_name, rabbit_config, **kwargs)
+        all_clients.append(client)
+        return client.start()
 
-    yield make_proxy
+    yield make_client
 
-    for proxy in all_proxies:
-        proxy.stop()
+    for client in all_clients:
+        client.stop()
 
 
 def test_shop_checkout_integration(
-    rabbit_config, runner_factory, rpc_proxy_factory
+    rabbit_config, runner_factory, rpc_client_factory
 ):
     """ Simulate a checkout flow as an integration test.
 
     Requires instances of AcmeShopService, StockService and InvoiceService
-    to be running. Explicitly replaces the rpc proxy to PaymentService so
+    to be running. Explicitly replaces the rpc client to PaymentService so
     that service doesn't need to be hosted.
 
     Also replaces the event dispatcher dependency on AcmeShopService and
@@ -281,7 +281,7 @@ def test_shop_checkout_integration(
     eliminates undesirable side-effects (e.g. processing events unnecessarily).
     """
     context_data = {'user_id': 'wile_e_coyote'}
-    shop = rpc_proxy_factory('acmeshopservice', context_data=context_data)
+    shop = rpc_client_factory('acmeshopservice', context_data=context_data)
 
     runner = runner_factory(
         rabbit_config, AcmeShopService, StockService, InvoiceService)

--- a/docs/examples/testing/large_integration_test.py
+++ b/docs/examples/testing/large_integration_test.py
@@ -15,11 +15,11 @@ from collections import defaultdict
 
 import pytest
 
-from nameko.extensions import DependencyProvider
 from nameko.events import EventDispatcher, event_handler
 from nameko.exceptions import RemoteError
-from nameko.rpc import rpc, RpcProxy
-from nameko.standalone.rpc import ServiceRpcProxy
+from nameko.extensions import DependencyProvider
+from nameko.rpc import RpcProxy, rpc
+from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import replace_dependencies, restrict_entrypoints
 from nameko.testing.utils import get_container
 from nameko.timer import timer
@@ -256,7 +256,7 @@ def rpc_proxy_factory(rabbit_config):
     all_proxies = []
 
     def make_proxy(service_name, **kwargs):
-        proxy = ServiceRpcProxy(service_name, rabbit_config, **kwargs)
+        proxy = ServiceRpcClient(service_name, rabbit_config, **kwargs)
         all_proxies.append(proxy)
         return proxy.start()
 

--- a/docs/examples/testing/unit_test.py
+++ b/docs/examples/testing/unit_test.py
@@ -25,7 +25,7 @@ def test_conversion_service():
     # create worker with mock dependencies
     service = worker_factory(ConversionService)
 
-    # add side effects to the mock proxy to the "maths" service
+    # add side effects to the mock rpc dependency on the "maths" service
     service.maths_rpc.multiply.side_effect = lambda x, y: x * y
     service.maths_rpc.divide.side_effect = lambda x, y: x / y
 

--- a/docs/examples/testing/unit_test.py
+++ b/docs/examples/testing/unit_test.py
@@ -1,7 +1,7 @@
 """ Service unit testing best practice.
 """
 
-from nameko.rpc import RpcProxy, rpc
+from nameko.rpc import ServiceRpc, rpc
 from nameko.testing.services import worker_factory
 
 
@@ -10,7 +10,7 @@ class ConversionService(object):
     """
     name = "conversions"
 
-    maths_rpc = RpcProxy("maths")
+    maths_rpc = ServiceRpc("maths")
 
     @rpc
     def inches_to_cm(self, inches):

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -86,6 +86,7 @@ parallelization
 parallelize
 plugin
 pre
+preconfigured
 prefetch
 programmatically
 pseudocode
@@ -99,10 +100,10 @@ reconnected
 reconnecting
 reconnection
 redis
-regex
 refactor
 refactored
 refactors
+regex
 renderer
 requeue
 requeued

--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -62,11 +62,11 @@ Usage:
 
     >>> n.dispatch_event('service', 'event_type', 'event_data')
 """
-    proxy = ClusterRpcClient(config)
-    module.rpc = proxy.start()
+    client = ClusterRpcClient(config)
+    module.rpc = client.start()
     module.dispatch_event = event_dispatcher(config)
     module.config = config
-    module.disconnect = proxy.stop
+    module.disconnect = client.stop
     return module
 
 

--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -7,7 +7,7 @@ import yaml
 
 from nameko.constants import AMQP_URI_CONFIG_KEY
 from nameko.standalone.events import event_dispatcher
-from nameko.standalone.rpc import ClusterRpcProxy
+from nameko.standalone.rpc import ClusterRpcClient
 
 from .commands import Shell
 
@@ -62,7 +62,7 @@ Usage:
 
     >>> n.dispatch_event('service', 'event_type', 'event_data')
 """
-    proxy = ClusterRpcProxy(config)
+    proxy = ClusterRpcClient(config)
     module.rpc = proxy.start()
     module.dispatch_event = event_dispatcher(config)
     module.config = config

--- a/nameko/rpc.py
+++ b/nameko/rpc.py
@@ -41,7 +41,7 @@ RESTRICTED_PUBLISHER_OPTIONS = (
     'exchange', 'routing_key', 'mandatory', 'reply_to', 'correlation_id'
 )
 """
-Publisher options that cannot be overridden when configuring an RPC proxy
+Publisher options that cannot be overridden when configuring an RPC client
 """
 
 
@@ -392,12 +392,11 @@ class ReplyListener(SharedExtension):
             _log.debug("Unknown correlation id: %s", correlation_id)
 
 
-class RpcProxy(DependencyProvider):
-    """ DependencyProvider for injecting an RPC proxy into a service.
+class ClusterRpc(DependencyProvider):
+    """ DependencyProvider for injecting an RPC client to a cluster of services into a
+    service.
 
     :Parameters:
-        target_service : str
-            Optional preconfigured target service name
         **publisher_options
             Options to configure the :class:`~nameko.amqqp.publish.Publisher`
             that sends the message.
@@ -407,8 +406,7 @@ class RpcProxy(DependencyProvider):
 
     reply_listener = ReplyListener()
 
-    def __init__(self, target_service=None, **publisher_options):
-        self.target_service = target_service
+    def __init__(self, **publisher_options):
         for option in RESTRICTED_PUBLISHER_OPTIONS:
             publisher_options.pop(option, None)
         self.publisher_options = publisher_options
@@ -451,30 +449,50 @@ class RpcProxy(DependencyProvider):
 
         register_for_reply = self.reply_listener.register_for_reply
 
-        proxy = Proxy(publish, register_for_reply)
-        if self.target_service:
-            proxy = getattr(proxy, self.target_service)
-        return proxy
+        return Client(publish, register_for_reply)
 
 
-class Proxy(object):
+class ServiceRpc(ClusterRpc):
+    """ DependencyProvider for injecting an RPC client to a specific service into a
+    service.
+
+    As per :class:`~nameko.rpc.ClusterRpc` but with a pre-specified target service.
+
+    :Parameters:
+        target_service : str
+            Target service name
+    """
+
+    def __init__(self, target_service, **kwargs):
+        self.target_service = target_service
+        super(ServiceRpc, self).__init__(**kwargs)
+
+    def get_dependency(self, worker_ctx):
+        client = super(ServiceRpc, self).get_dependency(worker_ctx)
+        return getattr(client, self.target_service)
+
+
+
+
+
+class Client(object):
     """ Helper object for making RPC calls.
 
     The target service and method name may be specified at construction time
     or by attribute or dict access, for example:
 
         # target at construction time
-        proxy = Proxy(
+        client = Client(
             publish, register_for_reply, "target_service", "target_method"
         )
-        proxy(*args, **kwargs)
+        client(*args, **kwargs)
 
         # equivalent with attribute access
-        proxy = Proxy(publish, register_for_reply)
-        proxy = proxy.target_service.target_method  # proxy now fully-specified
-        proxy(*args, **kwargs)
+        client = Client(publish, register_for_reply)
+        client = client.target_service.target_method  # client now fully-specified
+        client(*args, **kwargs)
 
-    Calling a fully-specified `Proxy` will make the RPC call and block for the
+    Calling a fully-specified `Client` will make the RPC call and block for the
     result. The `call_async` method initiates the call but returns an
     `RpcReply` object that can be used later to retrieve the result.
 
@@ -509,7 +527,7 @@ class Proxy(object):
             target_service = name
             target_method = None
 
-        clone = Proxy(
+        clone = Client(
             self.publish,
             self.register_for_reply,
             target_service,
@@ -531,7 +549,7 @@ class Proxy(object):
         )
 
     def __getitem__(self, name):
-        """Enable dict-like access on the proxy. """
+        """Enable dict-like access on the client. """
         return getattr(self, name)
 
     def __call__(self, *args, **kwargs):
@@ -565,7 +583,7 @@ class Proxy(object):
         # first, so by the time kombu returns (after waiting for the confim)
         # we can reliably check for returned messages.
 
-        # Note that deactivating publish-confirms in the RpcProxy will disable
+        # Note that deactivating publish-confirms in the Client will disable
         # this functionality and therefore :class:`UnknownService` will never
         # be raised (and the caller will hang).
 
@@ -585,6 +603,7 @@ class Proxy(object):
             raise UnknownService(self.service_name)
 
         return rpc_call
+
 
 
 class RpcCall(object):
@@ -633,3 +652,7 @@ class RpcCall(object):
         if error:
             raise deserialize(error)
         return response['result']
+
+
+RpcProxy = ServiceRpc  # backwards compat
+Proxy = Client  # backwards compat

--- a/nameko/rpc.py
+++ b/nameko/rpc.py
@@ -397,7 +397,7 @@ class RpcProxy(DependencyProvider):
 
     :Parameters:
         target_service : str
-            Target service name
+            Optional preconfigured target service name
         **publisher_options
             Options to configure the :class:`~nameko.amqqp.publish.Publisher`
             that sends the message.
@@ -407,7 +407,7 @@ class RpcProxy(DependencyProvider):
 
     reply_listener = ReplyListener()
 
-    def __init__(self, target_service, **publisher_options):
+    def __init__(self, target_service=None, **publisher_options):
         self.target_service = target_service
         for option in RESTRICTED_PUBLISHER_OPTIONS:
             publisher_options.pop(option, None)
@@ -452,7 +452,9 @@ class RpcProxy(DependencyProvider):
         register_for_reply = self.reply_listener.register_for_reply
 
         proxy = Proxy(publish, register_for_reply)
-        return getattr(proxy, self.target_service)
+        if self.target_service:
+            proxy = getattr(proxy, self.target_service)
+        return proxy
 
 
 class Proxy(object):

--- a/nameko/rpc.py
+++ b/nameko/rpc.py
@@ -393,8 +393,8 @@ class ReplyListener(SharedExtension):
 
 
 class ClusterRpc(DependencyProvider):
-    """ DependencyProvider for injecting an RPC client to a cluster of services into a
-    service.
+    """ DependencyProvider for injecting an RPC client to a cluster of
+    services into a service.
 
     :Parameters:
         **publisher_options
@@ -453,10 +453,11 @@ class ClusterRpc(DependencyProvider):
 
 
 class ServiceRpc(ClusterRpc):
-    """ DependencyProvider for injecting an RPC client to a specific service into a
-    service.
+    """ DependencyProvider for injecting an RPC client to a specific service
+    into a service.
 
-    As per :class:`~nameko.rpc.ClusterRpc` but with a pre-specified target service.
+    As per :class:`~nameko.rpc.ClusterRpc` but with a pre-specified target
+    service.
 
     :Parameters:
         target_service : str
@@ -470,9 +471,6 @@ class ServiceRpc(ClusterRpc):
     def get_dependency(self, worker_ctx):
         client = super(ServiceRpc, self).get_dependency(worker_ctx)
         return getattr(client, self.target_service)
-
-
-
 
 
 class Client(object):
@@ -489,7 +487,7 @@ class Client(object):
 
         # equivalent with attribute access
         client = Client(publish, register_for_reply)
-        client = client.target_service.target_method  # client now fully-specified
+        client = client.target_service.target_method  # now fully-specified
         client(*args, **kwargs)
 
     Calling a fully-specified `Client` will make the RPC call and block for the
@@ -603,7 +601,6 @@ class Client(object):
             raise UnknownService(self.service_name)
 
         return rpc_call
-
 
 
 class RpcCall(object):

--- a/nameko/rpc.py
+++ b/nameko/rpc.py
@@ -651,5 +651,5 @@ class RpcCall(object):
         return response['result']
 
 
-RpcProxy = ServiceRpc  # backwards compat
+ServiceRpc = ServiceRpc  # backwards compat
 Proxy = Client  # backwards compat

--- a/nameko/standalone/__init__.py
+++ b/nameko/standalone/__init__.py
@@ -8,12 +8,12 @@ initiate some action inside a nameko cluster.
 Examples:
 
 
-Use the RPC proxy to perform some addition on ``mathsservice``::
+Use the RPC client to perform some addition on ``mathsservice``::
 
-    >>> from nameko.standalone.rpc import rpc_proxy
+    >>> from nameko.standalone.rpc import ServiceRpcClient
     >>>
-    >>> with rpc_proxy("mathsservice", config) as proxy:
-    ...     result = proxy.add(2, 2)
+    >>> with ServiceRpcClient("mathsservice", config) as client:
+    ...     result = client.add(2, 2)
     ...
     >>> print result
     4

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -143,7 +143,7 @@ class ReplyListener(object):
         self.pending[correlation_id] = body
 
 
-class ClusterRpc(object):
+class ClusterRpcClient(object):
     """
     Single-threaded RPC client to a cluster of services. The target service
     and method are specified with attributes.
@@ -268,7 +268,7 @@ class ClusterRpc(object):
         self.reply_listener.stop()
 
 
-class ServiceRpc(ClusterRpc):
+class ServiceRpcClient(ClusterRpcClient):
     """
     Single-threaded RPC client to a named service.
 
@@ -277,9 +277,9 @@ class ServiceRpc(ClusterRpc):
     """
 
     def __init__(self, service_name, *args, **kwargs):
-        super(ServiceRpc, self).__init__(*args, **kwargs)
+        super(ServiceRpcClient, self).__init__(*args, **kwargs)
         self.client = getattr(self.client, service_name)
 
 
-ClusterRpcProxy = ClusterRpc  # backwards compat
-ServiceRpcProxy = ServiceRpc  # backwards compat
+ClusterRpcProxy = ClusterRpcClient  # backwards compat
+ServiceRpcProxy = ServiceRpcClient  # backwards compat

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -281,5 +281,5 @@ class ServiceRpcClient(ClusterRpcClient):
         self.client = getattr(self.client, service_name)
 
 
-ClusterRpcProxy = ClusterRpcClient  # backwards compat
-ServiceRpcProxy = ServiceRpcClient  # backwards compat
+ClusterRpcClient = ClusterRpcClient  # backwards compat
+ServiceRpcClient = ServiceRpcClient  # backwards compat

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -293,8 +293,8 @@ def predictable_call_ids(request):
     import itertools
     from mock import patch
 
-    with patch('nameko.standalone.rpc.uuid') as proxy_uuid:
-        proxy_uuid.uuid4.side_effect = (str(i) for i in itertools.count())
+    with patch('nameko.standalone.rpc.uuid') as client_uuid:
+        client_uuid.uuid4.side_effect = (str(i) for i in itertools.count())
         with patch('nameko.containers.uuid', autospec=True) as call_uuid:
             call_uuid.uuid4.side_effect = (str(i) for i in itertools.count())
             yield call_uuid.uuid4

--- a/nameko/testing/services.py
+++ b/nameko/testing/services.py
@@ -353,7 +353,7 @@ def replace_dependencies(container, *dependencies, **dependency_map):
     ::
 
         from nameko.rpc import RpcProxy, rpc
-        from nameko.standalone.rpc import ServiceRpcProxy
+        from nameko.standalone.rpc import ServiceRpcClient
 
         class ConversionService(object):
             name = "conversions"
@@ -374,7 +374,7 @@ def replace_dependencies(container, *dependencies, **dependency_map):
 
         container.start()
 
-        with ServiceRpcProxy('conversions', config) as proxy:
+        with ServiceRpcClient('conversions', config) as proxy:
             proxy.cm_to_inches(100)
 
         # assert that the dependency was called as expected
@@ -394,7 +394,7 @@ def replace_dependencies(container, *dependencies, **dependency_map):
 
         container.start()
 
-        with ServiceRpcProxy('conversions', config) as proxy:
+        with ServiceRpcClient('conversions', config) as proxy:
             assert proxy.cm_to_inches(127) == 50.0
 
     """

--- a/nameko/testing/services.py
+++ b/nameko/testing/services.py
@@ -220,14 +220,14 @@ def worker_factory(service_cls, **dependencies):
     **Usage**
 
     The following example service proxies calls to a "maths" service via
-    an ``RpcProxy`` dependency::
+    an ``ServiceRpc`` dependency::
 
-        from nameko.rpc import RpcProxy, rpc
+        from nameko.rpc import ServiceRpc, rpc
 
         class ConversionService(object):
             name = "conversions"
 
-            maths_rpc = RpcProxy("maths")
+            maths_rpc = ServiceRpc("maths")
 
             @rpc
             def inches_to_cm(self, inches):
@@ -352,13 +352,13 @@ def replace_dependencies(container, *dependencies, **dependency_map):
 
     ::
 
-        from nameko.rpc import RpcProxy, rpc
+        from nameko.rpc import ServiceRpc, rpc
         from nameko.standalone.rpc import ServiceRpcClient
 
         class ConversionService(object):
             name = "conversions"
 
-            maths_rpc = RpcProxy("maths")
+            maths_rpc = ServiceRpc("maths")
 
             @rpc
             def inches_to_cm(self, inches):

--- a/nameko/testing/services.py
+++ b/nameko/testing/services.py
@@ -374,8 +374,8 @@ def replace_dependencies(container, *dependencies, **dependency_map):
 
         container.start()
 
-        with ServiceRpcClient('conversions', config) as proxy:
-            proxy.cm_to_inches(100)
+        with ServiceRpcClient('conversions', config) as client:
+            client.cm_to_inches(100)
 
         # assert that the dependency was called as expected
         mock_maths_rpc.divide.assert_called_once_with(100, 2.54)
@@ -394,8 +394,8 @@ def replace_dependencies(container, *dependencies, **dependency_map):
 
         container.start()
 
-        with ServiceRpcClient('conversions', config) as proxy:
-            assert proxy.cm_to_inches(127) == 50.0
+        with ServiceRpcClient('conversions', config) as client:
+            assert client.cm_to_inches(127) == 50.0
 
     """
     if set(dependencies).intersection(dependency_map):

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -42,8 +42,8 @@ def test_run(rabbit_config):
         gt = eventlet.spawn(main, args)
 
     # make sure service launches ok
-    with ClusterRpcClient(rabbit_config) as proxy:
-        proxy.service.ping()
+    with ClusterRpcClient(rabbit_config) as client:
+        client.service.ping()
 
     # stop service
     pid = os.getpid()
@@ -123,8 +123,8 @@ def test_main_with_logging_config(rabbit_config, tmpdir):
     with wait_for_call(ServiceRunner, 'start'):
         gt = eventlet.spawn(main, args)
 
-    with ClusterRpcClient(rabbit_config) as proxy:
-        proxy.service.ping()
+    with ClusterRpcClient(rabbit_config) as client:
+        client.service.ping()
 
     pid = os.getpid()
     os.kill(pid, signal.SIGTERM)

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -16,7 +16,7 @@ from nameko.constants import (
 )
 from nameko.exceptions import CommandError
 from nameko.runners import ServiceRunner
-from nameko.standalone.rpc import ClusterRpcProxy
+from nameko.standalone.rpc import ClusterRpcClient
 from nameko.testing.waiting import wait_for_call
 
 from test.sample import Service
@@ -42,7 +42,7 @@ def test_run(rabbit_config):
         gt = eventlet.spawn(main, args)
 
     # make sure service launches ok
-    with ClusterRpcProxy(rabbit_config) as proxy:
+    with ClusterRpcClient(rabbit_config) as proxy:
         proxy.service.ping()
 
     # stop service
@@ -123,7 +123,7 @@ def test_main_with_logging_config(rabbit_config, tmpdir):
     with wait_for_call(ServiceRunner, 'start'):
         gt = eventlet.spawn(main, args)
 
-    with ClusterRpcProxy(rabbit_config) as proxy:
+    with ClusterRpcClient(rabbit_config) as proxy:
         proxy.service.ping()
 
     pid = os.getpid()

--- a/test/cli/test_shell.py
+++ b/test/cli/test_shell.py
@@ -10,12 +10,12 @@ from nameko.cli.shell import make_nameko_helper
 from nameko.constants import (
     AMQP_URI_CONFIG_KEY, SERIALIZER_CONFIG_KEY, WEB_SERVER_CONFIG_KEY
 )
-from nameko.rpc import Proxy
+from nameko.rpc import Client
 
 
 def test_helper_module(rabbit_config):
     helper = make_nameko_helper(rabbit_config)
-    assert isinstance(helper.rpc, Proxy)
+    assert isinstance(helper.rpc, Client)
     helper.disconnect()
 
 

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -18,7 +18,7 @@ from nameko.exceptions import (
 from nameko.extensions import DependencyProvider
 from nameko.rpc import Responder, get_rpc_exchange, rpc
 from nameko.standalone.rpc import (
-    ClusterRpcProxy, ReplyListener, ServiceRpc, ServiceRpcProxy
+    ClusterRpcProxy, ReplyListener, ServiceRpcProxy
 )
 from nameko.testing.waiting import wait_for_call
 
@@ -685,21 +685,21 @@ class TestStandaloneProxyDisconnections(object):
             retry = True
 
         with patch.object(
-            ServiceRpc.publisher_cls, 'retry', new=retry
+            ServiceRpcProxy.publisher_cls, 'retry', new=retry
         ):
             yield
 
     @pytest.yield_fixture(params=[True, False])
     def use_confirms(self, request):
         with patch.object(
-            ServiceRpc.publisher_cls, 'use_confirms',
+            ServiceRpcProxy.publisher_cls, 'use_confirms',
             new=request.param
         ):
             yield request.param
 
     @pytest.yield_fixture(autouse=True)
     def toxic_rpc_proxy(self, toxiproxy):
-        with patch.object(ServiceRpc, 'amqp_uri', new=toxiproxy.uri):
+        with patch.object(ServiceRpcProxy, 'amqp_uri', new=toxiproxy.uri):
             yield
 
     @pytest.yield_fixture

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -580,7 +580,7 @@ class TestConfigurability(object):
     def test_regular_parameters(
         self, parameter, mock_container, producer
     ):
-        """ Verify that most parameters can be specified at RpcProxy
+        """ Verify that most parameters can be specified at ServiceRpc
         instantiation time.
         """
         config = {'AMQP_URI': 'memory://localhost'}

--- a/test/test_amqp.py
+++ b/test/test_amqp.py
@@ -11,7 +11,7 @@ from nameko.events import EventHandler, event_handler
 from nameko.messaging import Consumer, consume
 from nameko.rpc import ReplyListener, RpcConsumer, RpcProxy, rpc
 from nameko.standalone.events import event_dispatcher
-from nameko.standalone.rpc import ServiceRpcProxy
+from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import entrypoint_waiter, once
 from nameko.testing.utils import get_extension
 
@@ -252,7 +252,7 @@ class TestHeartbeatFailure(object):
             container, 'method', callback=lambda *a: next(counter) == 2
         ):
             # make two requests; the second will block on the worker pool
-            with ServiceRpcProxy('service', config) as service_rpc:
+            with ServiceRpcClient('service', config) as service_rpc:
                 service_rpc.method.call_async(1)
                 service_rpc.method.call_async(2)
 

--- a/test/test_amqp.py
+++ b/test/test_amqp.py
@@ -9,7 +9,7 @@ from nameko.amqp.publish import Publisher
 from nameko.constants import DEFAULT_HEARTBEAT, HEARTBEAT_CONFIG_KEY
 from nameko.events import EventHandler, event_handler
 from nameko.messaging import Consumer, consume
-from nameko.rpc import ReplyListener, RpcConsumer, RpcProxy, rpc
+from nameko.rpc import ReplyListener, RpcConsumer, ServiceRpc, rpc
 from nameko.standalone.events import event_dispatcher
 from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import entrypoint_waiter, once
@@ -45,7 +45,7 @@ class TestDeadlockRegression(object):
         class Service(object):
             name = "downsteam"
 
-            upstream_rpc = RpcProxy("upstream")
+            upstream_rpc = ServiceRpc("upstream")
 
             @event_handler('service', 'event1')
             def handle_event1(self, event_data):
@@ -99,7 +99,7 @@ class TestHeartbeats(object):
         class Service(object):
             name = "service"
 
-            upstream_rpc = RpcProxy("upstream")
+            upstream_rpc = ServiceRpc("upstream")
 
             @consume(queue=Queue(name="queue"))
             @event_handler("service", "event")

--- a/test/test_call_id_stack.py
+++ b/test/test_call_id_stack.py
@@ -5,7 +5,7 @@ from nameko.constants import PARENT_CALLS_CONFIG_KEY
 from nameko.containers import WorkerContext
 from nameko.events import EventDispatcher, event_handler
 from nameko.extensions import DependencyProvider
-from nameko.rpc import RpcProxy, rpc
+from nameko.rpc import ServiceRpc, rpc
 from nameko.testing.services import entrypoint_hook, entrypoint_waiter
 from nameko.testing.utils import DummyProvider, get_container
 
@@ -93,7 +93,7 @@ def test_call_id_stack(
         name = "parent"
 
         stack_logger = StackLogger()
-        child_service = RpcProxy('child')
+        child_service = ServiceRpc('child')
 
         @rpc
         def method(self):
@@ -103,7 +103,7 @@ def test_call_id_stack(
         name = "grandparent"
 
         stack_logger = StackLogger()
-        parent_service = RpcProxy('parent')
+        parent_service = ServiceRpc('parent')
 
         @rpc
         def method(self):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -6,7 +6,7 @@ from mock import ANY, call, patch
 from nameko.events import EventDispatcher
 from nameko.exceptions import RemoteError
 from nameko.rpc import RpcConsumer, RpcProxy, rpc
-from nameko.standalone.rpc import ServiceRpcProxy
+from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import entrypoint_hook
 from nameko.testing.utils import get_container, get_extension
 
@@ -104,7 +104,7 @@ def test_handle_result_error(container_factory, rabbit_config):
         handle_result.side_effect = Exception(err)
 
         # use a standalone rpc proxy to call exampleservice.task()
-        with ServiceRpcProxy("exampleservice", rabbit_config) as proxy:
+        with ServiceRpcClient("exampleservice", rabbit_config) as proxy:
             # proxy.task() will hang forever because it generates an error
             proxy.task.call_async()
 
@@ -128,7 +128,7 @@ def test_dependency_call_lifecycle_errors(
         method.side_effect = Exception(err)
 
         # use a standalone rpc proxy to call exampleservice.task()
-        with ServiceRpcProxy("exampleservice", rabbit_config) as proxy:
+        with ServiceRpcClient("exampleservice", rabbit_config) as proxy:
             # proxy.task() will hang forever because it generates an error
             proxy.task.call_async()
 
@@ -152,7 +152,7 @@ def test_runner_catches_container_errors(runner_factory, rabbit_config):
         handle_result.side_effect = exception
 
         # use a standalone rpc proxy to call exampleservice.task()
-        with ServiceRpcProxy("exampleservice", rabbit_config) as proxy:
+        with ServiceRpcClient("exampleservice", rabbit_config) as proxy:
             # proxy.task() will hang forever because it generates an error
             # in the remote container (so never receives a response).
             proxy.task.call_async()
@@ -180,7 +180,7 @@ def test_graceful_stop_on_one_container_error(runner_factory, rabbit_config):
             handle_result.side_effect = exception
 
             # use a standalone rpc proxy to call exampleservice.task()
-            with ServiceRpcProxy("exampleservice", rabbit_config) as proxy:
+            with ServiceRpcClient("exampleservice", rabbit_config) as proxy:
                 # proxy.task() will hang forever because it generates an error
                 # in the remote container (so never receives a response).
                 proxy.task.call_async()

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -5,7 +5,7 @@ from mock import ANY, call, patch
 
 from nameko.events import EventDispatcher
 from nameko.exceptions import RemoteError
-from nameko.rpc import RpcConsumer, RpcProxy, rpc
+from nameko.rpc import RpcConsumer, ServiceRpc, rpc
 from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import entrypoint_hook
 from nameko.testing.utils import get_container, get_extension
@@ -19,7 +19,7 @@ class ExampleService(object):
     name = "exampleservice"
 
     dispatch = EventDispatcher()
-    rpcproxy = RpcProxy('exampleservice')
+    rpcproxy = ServiceRpc('exampleservice')
 
     @rpc
     def task(self):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -19,7 +19,7 @@ class ExampleService(object):
     name = "exampleservice"
 
     dispatch = EventDispatcher()
-    rpcproxy = ServiceRpc('exampleservice')
+    exampleservice_rpc = ServiceRpc('exampleservice')
 
     @rpc
     def task(self):
@@ -35,10 +35,10 @@ class ExampleService(object):
 
     @rpc
     def proxy(self, method, *args):
-        """ Proxies RPC calls to ``method`` on itself, so we can test handling
+        """ Makes RPC calls to ``method`` on itself, so we can test handling
         of errors in remote services.
         """
-        getattr(self.rpcproxy, method)(*args)
+        getattr(self.exampleservice_rpc, method)(*args)
 
 
 class SecondService(object):
@@ -103,10 +103,10 @@ def test_handle_result_error(container_factory, rabbit_config):
         err = "error in handle_result"
         handle_result.side_effect = Exception(err)
 
-        # use a standalone rpc proxy to call exampleservice.task()
-        with ServiceRpcClient("exampleservice", rabbit_config) as proxy:
-            # proxy.task() will hang forever because it generates an error
-            proxy.task.call_async()
+        # use a standalone rpc client to call exampleservice.task()
+        with ServiceRpcClient("exampleservice", rabbit_config) as client:
+            # client.task() will hang forever because it generates an error
+            client.task.call_async()
 
         with pytest.raises(Exception) as exc_info:
             container.wait()
@@ -127,10 +127,10 @@ def test_dependency_call_lifecycle_errors(
         err = "error in {}".format(method_name)
         method.side_effect = Exception(err)
 
-        # use a standalone rpc proxy to call exampleservice.task()
-        with ServiceRpcClient("exampleservice", rabbit_config) as proxy:
-            # proxy.task() will hang forever because it generates an error
-            proxy.task.call_async()
+        # use a standalone rpc client to call exampleservice.task()
+        with ServiceRpcClient("exampleservice", rabbit_config) as client:
+            # client.task() will hang forever because it generates an error
+            client.task.call_async()
 
         # verify that the error bubbles up to container.wait()
         with pytest.raises(Exception) as exc_info:
@@ -151,11 +151,11 @@ def test_runner_catches_container_errors(runner_factory, rabbit_config):
         exception = Exception("error")
         handle_result.side_effect = exception
 
-        # use a standalone rpc proxy to call exampleservice.task()
-        with ServiceRpcClient("exampleservice", rabbit_config) as proxy:
-            # proxy.task() will hang forever because it generates an error
+        # use a standalone rpc client to call exampleservice.task()
+        with ServiceRpcClient("exampleservice", rabbit_config) as client:
+            # client.task() will hang forever because it generates an error
             # in the remote container (so never receives a response).
-            proxy.task.call_async()
+            client.task.call_async()
 
         # verify that the error bubbles up to runner.wait()
         with pytest.raises(Exception) as exc_info:
@@ -179,11 +179,11 @@ def test_graceful_stop_on_one_container_error(runner_factory, rabbit_config):
             exception = Exception("error")
             handle_result.side_effect = exception
 
-            # use a standalone rpc proxy to call exampleservice.task()
-            with ServiceRpcClient("exampleservice", rabbit_config) as proxy:
-                # proxy.task() will hang forever because it generates an error
+            # use a standalone rpc client to call exampleservice.task()
+            with ServiceRpcClient("exampleservice", rabbit_config) as client:
+                # client.task() will hang forever because it generates an error
                 # in the remote container (so never receives a response).
-                proxy.task.call_async()
+                client.task.call_async()
 
             # verify that the error bubbles up to runner.wait()
             with pytest.raises(Exception) as exc_info:

--- a/test/test_handle_result.py
+++ b/test/test_handle_result.py
@@ -60,13 +60,13 @@ class ExampleService(object):
 
 
 @pytest.yield_fixture
-def rpc_proxy(rabbit_config):
-    with ServiceRpcClient('exampleservice', rabbit_config) as proxy:
-        yield proxy
+def rpc_client(rabbit_config):
+    with ServiceRpcClient('exampleservice', rabbit_config) as client:
+        yield client
 
 
 def test_handle_result(
-    container_factory, rabbit_manager, rabbit_config, rpc_proxy
+    container_factory, rabbit_manager, rabbit_config, rpc_client
 ):
     """ Verify that `handle_result` can modify the return values of the worker,
     such that other dependencies see the updated values.
@@ -74,13 +74,13 @@ def test_handle_result(
     container = container_factory(ExampleService, rabbit_config)
     container.start()
 
-    assert rpc_proxy.echo("hello") == "hello"
+    assert rpc_client.echo("hello") == "hello"
 
-    # use entrypoint_waiter because the rpc proxy returns before
+    # use entrypoint_waiter because the rpc client returns before
     # worker_result is called
     with entrypoint_waiter(container, "unserializable"):
         with pytest.raises(RemoteError) as exc:
-            rpc_proxy.unserializable()
+            rpc_client.unserializable()
         assert "is not JSON serializable" in str(exc.value)
 
     # verify ResultCollector sees values returned from `handle_result`

--- a/test/test_handle_result.py
+++ b/test/test_handle_result.py
@@ -7,7 +7,7 @@ from mock import ANY
 from nameko.exceptions import RemoteError
 from nameko.extensions import DependencyProvider
 from nameko.rpc import Rpc
-from nameko.standalone.rpc import ServiceRpcProxy
+from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import entrypoint_waiter
 
 
@@ -61,7 +61,7 @@ class ExampleService(object):
 
 @pytest.yield_fixture
 def rpc_proxy(rabbit_config):
-    with ServiceRpcProxy('exampleservice', rabbit_config) as proxy:
+    with ServiceRpcClient('exampleservice', rabbit_config) as proxy:
         yield proxy
 
 

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -23,7 +23,8 @@ from nameko.exceptions import (
 )
 from nameko.extensions import DependencyProvider
 from nameko.rpc import (
-    Proxy, ReplyListener, Responder, Rpc, RpcConsumer, RpcProxy, rpc
+    ClusterRpc, Proxy, ReplyListener, Responder, Rpc, RpcConsumer, RpcProxy,
+    rpc
 )
 from nameko.standalone.rpc import ServiceRpcProxy
 from nameko.testing.services import dummy, entrypoint_hook, entrypoint_waiter
@@ -382,7 +383,7 @@ def test_rpc_headers(container_factory, rabbit_config):
         assert headers == {
             'nameko.language': 'en',
             'nameko.otherheader': 'othervalue',
-            'nameko.call_id_stack': ['standalone_rpc_proxy.0.0']
+            'nameko.call_id_stack': ['standalone_rpc_client.0.0']
         }
 
 
@@ -751,7 +752,7 @@ def test_cluster_proxy(container_factory, rabbit_config):
     class Service(object):
         name = "service"
 
-        cluster_rpc = RpcProxy()
+        cluster_rpc = ClusterRpc()
 
         @dummy
         def echo(self, arg):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -13,7 +13,7 @@ from nameko.events import EventDispatcher, event_handler
 from nameko.exceptions import ConfigurationError, RemoteError
 from nameko.messaging import consume
 from nameko.rpc import RpcProxy, rpc
-from nameko.standalone.rpc import ServiceRpcProxy
+from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import entrypoint_hook, entrypoint_waiter
 
 
@@ -105,7 +105,7 @@ def test_rpc_serialization(container_factory, rabbit_config,
 
     serialized = serialized_info[serializer]
 
-    with ServiceRpcProxy('service', rabbit_config) as proxy:
+    with ServiceRpcClient('service', rabbit_config) as proxy:
         assert proxy.echo(test_data) == serialized['data']
         assert entrypoint_called.call_args == call(serialized['data'])
 
@@ -118,7 +118,7 @@ def test_rpc_result_serialization_error(container_factory, rabbit_config):
     container = container_factory(Service, rabbit_config)
     container.start()
 
-    with ServiceRpcProxy('service', rabbit_config) as proxy:
+    with ServiceRpcClient('service', rabbit_config) as proxy:
         with pytest.raises(RemoteError) as exc:
             proxy.broken()
         assert exc.value.exc_type == "UnserializableValueError"
@@ -131,7 +131,7 @@ def test_rpc_arg_serialization_error(container_factory, rabbit_config):
     container = container_factory(Service, rabbit_config)
     container.start()
 
-    with ServiceRpcProxy('service', rabbit_config) as proxy:
+    with ServiceRpcClient('service', rabbit_config) as proxy:
         with pytest.raises(Exception):
             proxy.echo(unserializable)
 
@@ -212,7 +212,7 @@ def test_custom_serializer(container_factory, rabbit_config,
     get_messages = sniffer_queue_factory('nameko-rpc')
 
     # verify RPC works end-to-end
-    with ServiceRpcProxy('service', rabbit_config) as proxy:
+    with ServiceRpcClient('service', rabbit_config) as proxy:
         assert proxy.echo("hello") == "hello"
 
     # verify sniffed messages serialized as expected
@@ -312,7 +312,7 @@ def test_standalone_rpc_accepts_multiple_serialization_formats(
 
     get_messages = sniffer_queue_factory('nameko-rpc')
 
-    with ServiceRpcProxy('echoer', proxy_config) as proxy:
+    with ServiceRpcClient('echoer', proxy_config) as proxy:
         assert proxy.echo(payload) == payload
 
     msg = get_messages().pop()

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -12,7 +12,7 @@ from nameko.constants import (
 from nameko.events import EventDispatcher, event_handler
 from nameko.exceptions import ConfigurationError, RemoteError
 from nameko.messaging import consume
-from nameko.rpc import RpcProxy, rpc
+from nameko.rpc import ServiceRpc, rpc
 from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import entrypoint_hook, entrypoint_waiter
 
@@ -340,7 +340,7 @@ def test_rpc_accepts_multiple_serialization_formats(
 
         name = 'forwarder'
 
-        echoer = RpcProxy('echoer')
+        echoer = ServiceRpc('echoer')
 
         @rpc
         def forward(self, payload):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -105,8 +105,8 @@ def test_rpc_serialization(container_factory, rabbit_config,
 
     serialized = serialized_info[serializer]
 
-    with ServiceRpcClient('service', rabbit_config) as proxy:
-        assert proxy.echo(test_data) == serialized['data']
+    with ServiceRpcClient('service', rabbit_config) as client:
+        assert client.echo(test_data) == serialized['data']
         assert entrypoint_called.call_args == call(serialized['data'])
 
     msg = get_messages()[0]
@@ -118,12 +118,12 @@ def test_rpc_result_serialization_error(container_factory, rabbit_config):
     container = container_factory(Service, rabbit_config)
     container.start()
 
-    with ServiceRpcClient('service', rabbit_config) as proxy:
+    with ServiceRpcClient('service', rabbit_config) as client:
         with pytest.raises(RemoteError) as exc:
-            proxy.broken()
+            client.broken()
         assert exc.value.exc_type == "UnserializableValueError"
 
-        assert proxy.echo('foo') == "foo"  # subsequent calls ok
+        assert client.echo('foo') == "foo"  # subsequent calls ok
 
 
 def test_rpc_arg_serialization_error(container_factory, rabbit_config):
@@ -131,11 +131,11 @@ def test_rpc_arg_serialization_error(container_factory, rabbit_config):
     container = container_factory(Service, rabbit_config)
     container.start()
 
-    with ServiceRpcClient('service', rabbit_config) as proxy:
+    with ServiceRpcClient('service', rabbit_config) as client:
         with pytest.raises(Exception):
-            proxy.echo(unserializable)
+            client.echo(unserializable)
 
-        assert proxy.echo('foo') == "foo"  # subsequent calls ok
+        assert client.echo('foo') == "foo"  # subsequent calls ok
 
 
 @pytest.mark.parametrize("serializer", ['json', 'pickle'])
@@ -212,8 +212,8 @@ def test_custom_serializer(container_factory, rabbit_config,
     get_messages = sniffer_queue_factory('nameko-rpc')
 
     # verify RPC works end-to-end
-    with ServiceRpcClient('service', rabbit_config) as proxy:
-        assert proxy.echo("hello") == "hello"
+    with ServiceRpcClient('service', rabbit_config) as client:
+        assert client.echo("hello") == "hello"
 
     # verify sniffed messages serialized as expected
     msg = get_messages()[0]
@@ -307,13 +307,13 @@ def test_standalone_rpc_accepts_multiple_serialization_formats(
 
     payload = {'spam': 'ham'}
 
-    proxy_config = rabbit_config.copy()
-    proxy_config[SERIALIZER_CONFIG_KEY] = serializer
+    client_config = rabbit_config.copy()
+    client_config[SERIALIZER_CONFIG_KEY] = serializer
 
     get_messages = sniffer_queue_factory('nameko-rpc')
 
-    with ServiceRpcClient('echoer', proxy_config) as proxy:
-        assert proxy.echo(payload) == payload
+    with ServiceRpcClient('echoer', client_config) as client:
+        assert client.echo(payload) == payload
 
     msg = get_messages().pop()
     assert encode(payload) in msg['payload']

--- a/test/test_service_runner.py
+++ b/test/test_service_runner.py
@@ -218,8 +218,8 @@ def test_multiple_runners_coexist(
 
     # test rpc (only one service will respond)
     arg = "arg"
-    with ServiceRpcClient('service', rabbit_config) as proxy:
-        proxy.handle(arg)
+    with ServiceRpcClient('service', rabbit_config) as client:
+        client.handle(arg)
 
     assert tracker.call_args_list == [
         call(event_data), call(event_data), call(arg)
@@ -250,8 +250,8 @@ def test_runner_with_duplicate_services(
 
     # test rpc
     arg = "arg"
-    with ServiceRpcClient("service", rabbit_config) as proxy:
-        proxy.handle(arg)
+    with ServiceRpcClient("service", rabbit_config) as client:
+        client.handle(arg)
 
     assert tracker.call_args_list == [call(event_data), call(arg)]
 

--- a/test/test_service_runner.py
+++ b/test/test_service_runner.py
@@ -5,7 +5,7 @@ from nameko.events import BROADCAST, event_handler
 from nameko.rpc import rpc
 from nameko.runners import ServiceRunner, run_services
 from nameko.standalone.events import event_dispatcher
-from nameko.standalone.rpc import ServiceRpcProxy
+from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import entrypoint_waiter
 from nameko.testing.utils import assert_stops_raising, get_container
 
@@ -218,7 +218,7 @@ def test_multiple_runners_coexist(
 
     # test rpc (only one service will respond)
     arg = "arg"
-    with ServiceRpcProxy('service', rabbit_config) as proxy:
+    with ServiceRpcClient('service', rabbit_config) as proxy:
         proxy.handle(arg)
 
     assert tracker.call_args_list == [
@@ -250,7 +250,7 @@ def test_runner_with_duplicate_services(
 
     # test rpc
     arg = "arg"
-    with ServiceRpcProxy("service", rabbit_config) as proxy:
+    with ServiceRpcClient("service", rabbit_config) as proxy:
         proxy.handle(arg)
 
     assert tracker.call_args_list == [call(event_data), call(arg)]

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -6,7 +6,7 @@ from six.moves import queue
 
 from nameko.constants import WEB_SERVER_CONFIG_KEY
 from nameko.extensions import DependencyProvider
-from nameko.rpc import RpcProxy, rpc
+from nameko.rpc import ServiceRpc, rpc
 from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing import rabbit
 from nameko.testing.utils import get_rabbit_connections
@@ -348,7 +348,7 @@ def test_predictable_call_ids(runner_factory, rabbit_config):
         name = "x"
 
         capture = CaptureWorkerContext()
-        service_y = RpcProxy("y")
+        service_y = ServiceRpc("y")
 
         @rpc
         def method(self):

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -7,7 +7,7 @@ from six.moves import queue
 from nameko.constants import WEB_SERVER_CONFIG_KEY
 from nameko.extensions import DependencyProvider
 from nameko.rpc import RpcProxy, rpc
-from nameko.standalone.rpc import ServiceRpcProxy
+from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing import rabbit
 from nameko.testing.utils import get_rabbit_connections
 from nameko.web.handlers import http
@@ -237,7 +237,7 @@ def test_container_factory(
     testdir.makepyfile(
         """
         from nameko.rpc import rpc
-        from nameko.standalone.rpc import ServiceRpcProxy
+        from nameko.standalone.rpc import ServiceRpcClient
 
         class ServiceX(object):
             name = "x"
@@ -250,7 +250,7 @@ def test_container_factory(
             container = container_factory(ServiceX, rabbit_config)
             container.start()
 
-            with ServiceRpcProxy("x", rabbit_config) as proxy:
+            with ServiceRpcClient("x", rabbit_config) as proxy:
                 assert proxy.method() == "OK"
         """
     )
@@ -273,7 +273,7 @@ def test_container_factory_with_custom_container_cls(testdir, plugin_options):
     testdir.makepyfile(
         """
         from nameko.rpc import rpc
-        from nameko.standalone.rpc import ServiceRpcProxy
+        from nameko.standalone.rpc import ServiceRpcClient
 
         from container_module import ServiceContainerX
 
@@ -296,7 +296,7 @@ def test_container_factory_with_custom_container_cls(testdir, plugin_options):
 
             assert isinstance(container, ServiceContainerX)
 
-            with ServiceRpcProxy("x", rabbit_config) as proxy:
+            with ServiceRpcClient("x", rabbit_config) as proxy:
                 assert proxy.method() == "OK"
         """
     )
@@ -311,7 +311,7 @@ def test_runner_factory(
     testdir.makepyfile(
         """
         from nameko.rpc import rpc
-        from nameko.standalone.rpc import ServiceRpcProxy
+        from nameko.standalone.rpc import ServiceRpcClient
 
         class ServiceX(object):
             name = "x"
@@ -324,7 +324,7 @@ def test_runner_factory(
             runner = runner_factory(rabbit_config, ServiceX)
             runner.start()
 
-            with ServiceRpcProxy("x", rabbit_config) as proxy:
+            with ServiceRpcClient("x", rabbit_config) as proxy:
                 assert proxy.method() == "OK"
         """
     )
@@ -366,7 +366,7 @@ def test_predictable_call_ids(runner_factory, rabbit_config):
     runner = runner_factory(rabbit_config, ServiceX, ServiceY)
     runner.start()
 
-    with ServiceRpcProxy("x", rabbit_config) as service_x:
+    with ServiceRpcClient("x", rabbit_config) as service_x:
         service_x.method()
 
     call_ids = [worker_ctx.call_id for worker_ctx in worker_contexts]

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -250,8 +250,8 @@ def test_container_factory(
             container = container_factory(ServiceX, rabbit_config)
             container.start()
 
-            with ServiceRpcClient("x", rabbit_config) as proxy:
-                assert proxy.method() == "OK"
+            with ServiceRpcClient("x", rabbit_config) as client:
+                assert client.method() == "OK"
         """
     )
     result = testdir.runpytest(*plugin_options)
@@ -296,8 +296,8 @@ def test_container_factory_with_custom_container_cls(testdir, plugin_options):
 
             assert isinstance(container, ServiceContainerX)
 
-            with ServiceRpcClient("x", rabbit_config) as proxy:
-                assert proxy.method() == "OK"
+            with ServiceRpcClient("x", rabbit_config) as client:
+                assert client.method() == "OK"
         """
     )
     result = testdir.runpytest(*plugin_options)
@@ -324,8 +324,8 @@ def test_runner_factory(
             runner = runner_factory(rabbit_config, ServiceX)
             runner.start()
 
-            with ServiceRpcClient("x", rabbit_config) as proxy:
-                assert proxy.method() == "OK"
+            with ServiceRpcClient("x", rabbit_config) as client:
+                assert client.method() == "OK"
         """
     )
     result = testdir.runpytest(*plugin_options)

--- a/test/testing/test_services.py
+++ b/test/testing/test_services.py
@@ -8,7 +8,7 @@ from mock import Mock, call
 from nameko.events import event_handler
 from nameko.exceptions import ExtensionNotFound, MethodNotFound
 from nameko.extensions import DependencyProvider
-from nameko.rpc import RpcProxy, rpc
+from nameko.rpc import ServiceRpc, rpc
 from nameko.standalone.events import event_dispatcher
 from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import (
@@ -74,7 +74,7 @@ def spawn_thread():
 class Service(object):
     name = "service"
 
-    a = RpcProxy("service_a")
+    a = ServiceRpc("service_a")
     language = LanguageReporter()
 
     @rpc
@@ -97,7 +97,7 @@ class Service(object):
 class ServiceA(object):
 
     name = "service_a"
-    b = RpcProxy("service_b")
+    b = ServiceRpc("service_b")
 
     @rpc
     def remote_method(self, value):
@@ -108,7 +108,7 @@ class ServiceA(object):
 class ServiceB(object):
 
     name = "service_b"
-    c = RpcProxy("service_c")
+    c = ServiceRpc("service_c")
 
     @rpc
     def remote_method(self, value):
@@ -209,8 +209,8 @@ def test_worker_factory():
 
     class Service(object):
         name = "service"
-        foo_proxy = RpcProxy("foo_service")
-        bar_proxy = RpcProxy("bar_service")
+        foo_proxy = ServiceRpc("foo_service")
+        bar_proxy = ServiceRpc("bar_service")
 
     class OtherService(object):
         pass
@@ -241,9 +241,9 @@ def test_replace_dependencies_kwargs(container_factory, rabbit_config):
 
     class Service(object):
         name = "service"
-        foo_proxy = RpcProxy("foo_service")
-        bar_proxy = RpcProxy("bar_service")
-        baz_proxy = RpcProxy("baz_service")
+        foo_proxy = ServiceRpc("foo_service")
+        bar_proxy = ServiceRpc("bar_service")
+        baz_proxy = ServiceRpc("baz_service")
 
         @rpc
         def method(self, arg):
@@ -262,14 +262,14 @@ def test_replace_dependencies_kwargs(container_factory, rabbit_config):
     fake_foo_proxy = FakeDependency()
     replace_dependencies(container, foo_proxy=fake_foo_proxy)
     assert 2 == len([dependency for dependency in container.extensions
-                     if isinstance(dependency, RpcProxy)])
+                     if isinstance(dependency, ServiceRpc)])
 
     # customise multiple dependencies
     res = replace_dependencies(container, bar_proxy=Mock(), baz_proxy=Mock())
     assert list(res) == []
 
-    # verify that container.extensions doesn't include an RpcProxy anymore
-    assert all([not isinstance(dependency, RpcProxy)
+    # verify that container.extensions doesn't include an ServiceRpc anymore
+    assert all([not isinstance(dependency, ServiceRpc)
                 for dependency in container.extensions])
 
     container.start()
@@ -286,9 +286,9 @@ def test_replace_dependencies_args(container_factory, rabbit_config):
 
     class Service(object):
         name = "service"
-        foo_proxy = RpcProxy("foo_service")
-        bar_proxy = RpcProxy("bar_service")
-        baz_proxy = RpcProxy("baz_service")
+        foo_proxy = ServiceRpc("foo_service")
+        bar_proxy = ServiceRpc("bar_service")
+        baz_proxy = ServiceRpc("baz_service")
 
         @rpc
         def method(self, arg):
@@ -303,8 +303,8 @@ def test_replace_dependencies_args(container_factory, rabbit_config):
     replacements = replace_dependencies(container, "bar_proxy", "baz_proxy")
     assert len([x for x in replacements]) == 2
 
-    # verify that container.extensions doesn't include an RpcProxy anymore
-    assert all([not isinstance(dependency, RpcProxy)
+    # verify that container.extensions doesn't include an ServiceRpc anymore
+    assert all([not isinstance(dependency, ServiceRpc)
                 for dependency in container.extensions])
 
     container.start()
@@ -321,9 +321,9 @@ def test_replace_dependencies_args_and_kwargs(container_factory,
                                               rabbit_config):
     class Service(object):
         name = "service"
-        foo_proxy = RpcProxy("foo_service")
-        bar_proxy = RpcProxy("bar_service")
-        baz_proxy = RpcProxy("baz_service")
+        foo_proxy = ServiceRpc("foo_service")
+        bar_proxy = ServiceRpc("bar_service")
+        baz_proxy = ServiceRpc("baz_service")
 
         @rpc
         def method(self, arg):
@@ -345,8 +345,8 @@ def test_replace_dependencies_args_and_kwargs(container_factory,
         container, 'bar_proxy', 'baz_proxy', foo_proxy=fake_foo_proxy
     )
 
-    # verify that container.extensions doesn't include an RpcProxy anymore
-    assert all([not isinstance(dependency, RpcProxy)
+    # verify that container.extensions doesn't include an ServiceRpc anymore
+    assert all([not isinstance(dependency, ServiceRpc)
                 for dependency in container.extensions])
 
     container.start()
@@ -365,9 +365,9 @@ def test_replace_dependencies_in_both_args_and_kwargs_error(container_factory,
                                                             rabbit_config):
     class Service(object):
         name = "service"
-        foo_proxy = RpcProxy("foo_service")
-        bar_proxy = RpcProxy("bar_service")
-        baz_proxy = RpcProxy("baz_service")
+        foo_proxy = ServiceRpc("foo_service")
+        bar_proxy = ServiceRpc("bar_service")
+        baz_proxy = ServiceRpc("baz_service")
 
     container = container_factory(Service, rabbit_config)
 
@@ -382,7 +382,7 @@ def test_replace_non_dependency(container_factory, rabbit_config):
 
     class Service(object):
         name = "service"
-        proxy = RpcProxy("foo_service")
+        proxy = ServiceRpc("foo_service")
 
         @rpc
         def method(self):
@@ -404,7 +404,7 @@ def test_replace_dependencies_container_already_started(container_factory,
 
     class Service(object):
         name = "service"
-        proxy = RpcProxy("foo_service")
+        proxy = ServiceRpc("foo_service")
 
     container = container_factory(Service, rabbit_config)
     container.start()

--- a/test/testing/test_services.py
+++ b/test/testing/test_services.py
@@ -10,7 +10,7 @@ from nameko.exceptions import ExtensionNotFound, MethodNotFound
 from nameko.extensions import DependencyProvider
 from nameko.rpc import RpcProxy, rpc
 from nameko.standalone.events import event_dispatcher
-from nameko.standalone.rpc import ServiceRpcProxy
+from nameko.standalone.rpc import ServiceRpcClient
 from nameko.testing.services import (
     entrypoint_hook, entrypoint_waiter, once, replace_dependencies,
     restrict_entrypoints, worker_factory
@@ -276,7 +276,7 @@ def test_replace_dependencies_kwargs(container_factory, rabbit_config):
 
     # verify that the fake dependency collected calls
     msg = "msg"
-    with ServiceRpcProxy("service", rabbit_config) as service_proxy:
+    with ServiceRpcClient("service", rabbit_config) as service_proxy:
         service_proxy.method(msg)
 
     assert fake_foo_proxy.processed == [msg]
@@ -311,7 +311,7 @@ def test_replace_dependencies_args(container_factory, rabbit_config):
 
     # verify that the mock dependency collects calls
     msg = "msg"
-    with ServiceRpcProxy("service", rabbit_config) as service_proxy:
+    with ServiceRpcClient("service", rabbit_config) as service_proxy:
         service_proxy.method(msg)
 
     foo_proxy.remote_method.assert_called_once_with(msg)
@@ -353,7 +353,7 @@ def test_replace_dependencies_args_and_kwargs(container_factory,
 
     # verify that the fake dependency collected calls
     msg = "msg"
-    with ServiceRpcProxy("service", rabbit_config) as service_proxy:
+    with ServiceRpcClient("service", rabbit_config) as service_proxy:
         service_proxy.method(msg)
 
     assert fake_foo_proxy.processed == [msg]
@@ -436,7 +436,7 @@ def test_restrict_entrypoints(container_factory, rabbit_config):
     container.start()
 
     # verify the rpc entrypoint on handler_one is disabled
-    with ServiceRpcProxy("service", rabbit_config) as service_proxy:
+    with ServiceRpcClient("service", rabbit_config) as service_proxy:
         with pytest.raises(MethodNotFound) as exc_info:
             service_proxy.handler_one("msg")
         assert str(exc_info.value) == "handler_one"

--- a/test/testing/test_services.py
+++ b/test/testing/test_services.py
@@ -209,8 +209,8 @@ def test_worker_factory():
 
     class Service(object):
         name = "service"
-        foo_proxy = ServiceRpc("foo_service")
-        bar_proxy = ServiceRpc("bar_service")
+        foo_client = ServiceRpc("foo_service")
+        bar_client = ServiceRpc("bar_service")
 
     class OtherService(object):
         pass
@@ -218,8 +218,8 @@ def test_worker_factory():
     # simplest case, no overrides
     instance = worker_factory(Service)
     assert isinstance(instance, Service)
-    assert isinstance(instance.foo_proxy, Mock)
-    assert isinstance(instance.bar_proxy, Mock)
+    assert isinstance(instance.foo_client, Mock)
+    assert isinstance(instance.bar_client, Mock)
 
     # no dependencies to replace
     instance = worker_factory(OtherService)
@@ -227,10 +227,10 @@ def test_worker_factory():
 
     # override specific dependency
     bar_dependency = object()
-    instance = worker_factory(Service, bar_proxy=bar_dependency)
+    instance = worker_factory(Service, bar_client=bar_dependency)
     assert isinstance(instance, Service)
-    assert isinstance(instance.foo_proxy, Mock)
-    assert instance.bar_proxy is bar_dependency
+    assert isinstance(instance.foo_client, Mock)
+    assert instance.bar_client is bar_dependency
 
     # non-applicable dependency
     with pytest.raises(ExtensionNotFound):
@@ -241,13 +241,13 @@ def test_replace_dependencies_kwargs(container_factory, rabbit_config):
 
     class Service(object):
         name = "service"
-        foo_proxy = ServiceRpc("foo_service")
-        bar_proxy = ServiceRpc("bar_service")
-        baz_proxy = ServiceRpc("baz_service")
+        foo_client = ServiceRpc("foo_service")
+        bar_client = ServiceRpc("bar_service")
+        baz_client = ServiceRpc("baz_service")
 
         @rpc
         def method(self, arg):
-            self.foo_proxy.remote_method(arg)
+            self.foo_client.remote_method(arg)
 
     class FakeDependency(object):
         def __init__(self):
@@ -259,13 +259,13 @@ def test_replace_dependencies_kwargs(container_factory, rabbit_config):
     container = container_factory(Service, rabbit_config)
 
     # customise a single dependency
-    fake_foo_proxy = FakeDependency()
-    replace_dependencies(container, foo_proxy=fake_foo_proxy)
+    fake_foo_client = FakeDependency()
+    replace_dependencies(container, foo_client=fake_foo_client)
     assert 2 == len([dependency for dependency in container.extensions
                      if isinstance(dependency, ServiceRpc)])
 
     # customise multiple dependencies
-    res = replace_dependencies(container, bar_proxy=Mock(), baz_proxy=Mock())
+    res = replace_dependencies(container, bar_client=Mock(), baz_client=Mock())
     assert list(res) == []
 
     # verify that container.extensions doesn't include an ServiceRpc anymore
@@ -276,31 +276,31 @@ def test_replace_dependencies_kwargs(container_factory, rabbit_config):
 
     # verify that the fake dependency collected calls
     msg = "msg"
-    with ServiceRpcClient("service", rabbit_config) as service_proxy:
-        service_proxy.method(msg)
+    with ServiceRpcClient("service", rabbit_config) as service_client:
+        service_client.method(msg)
 
-    assert fake_foo_proxy.processed == [msg]
+    assert fake_foo_client.processed == [msg]
 
 
 def test_replace_dependencies_args(container_factory, rabbit_config):
 
     class Service(object):
         name = "service"
-        foo_proxy = ServiceRpc("foo_service")
-        bar_proxy = ServiceRpc("bar_service")
-        baz_proxy = ServiceRpc("baz_service")
+        foo_client = ServiceRpc("foo_service")
+        bar_client = ServiceRpc("bar_service")
+        baz_client = ServiceRpc("baz_service")
 
         @rpc
         def method(self, arg):
-            self.foo_proxy.remote_method(arg)
+            self.foo_client.remote_method(arg)
 
     container = container_factory(Service, rabbit_config)
 
     # replace a single dependency
-    foo_proxy = replace_dependencies(container, "foo_proxy")
+    foo_client = replace_dependencies(container, "foo_client")
 
     # replace multiple dependencies
-    replacements = replace_dependencies(container, "bar_proxy", "baz_proxy")
+    replacements = replace_dependencies(container, "bar_client", "baz_client")
     assert len([x for x in replacements]) == 2
 
     # verify that container.extensions doesn't include an ServiceRpc anymore
@@ -311,25 +311,25 @@ def test_replace_dependencies_args(container_factory, rabbit_config):
 
     # verify that the mock dependency collects calls
     msg = "msg"
-    with ServiceRpcClient("service", rabbit_config) as service_proxy:
-        service_proxy.method(msg)
+    with ServiceRpcClient("service", rabbit_config) as service_client:
+        service_client.method(msg)
 
-    foo_proxy.remote_method.assert_called_once_with(msg)
+    foo_client.remote_method.assert_called_once_with(msg)
 
 
 def test_replace_dependencies_args_and_kwargs(container_factory,
                                               rabbit_config):
     class Service(object):
         name = "service"
-        foo_proxy = ServiceRpc("foo_service")
-        bar_proxy = ServiceRpc("bar_service")
-        baz_proxy = ServiceRpc("baz_service")
+        foo_client = ServiceRpc("foo_service")
+        bar_client = ServiceRpc("bar_service")
+        baz_client = ServiceRpc("baz_service")
 
         @rpc
         def method(self, arg):
-            self.foo_proxy.remote_method(arg)
-            self.bar_proxy.bar()
-            self.baz_proxy.baz()
+            self.foo_client.remote_method(arg)
+            self.bar_client.bar()
+            self.baz_client.baz()
 
     class FakeDependency(object):
         def __init__(self):
@@ -340,9 +340,9 @@ def test_replace_dependencies_args_and_kwargs(container_factory,
 
     container = container_factory(Service, rabbit_config)
 
-    fake_foo_proxy = FakeDependency()
-    mock_bar_proxy, mock_baz_proxy = replace_dependencies(
-        container, 'bar_proxy', 'baz_proxy', foo_proxy=fake_foo_proxy
+    fake_foo_client = FakeDependency()
+    mock_bar_client, mock_baz_client = replace_dependencies(
+        container, 'bar_client', 'baz_client', foo_client=fake_foo_client
     )
 
     # verify that container.extensions doesn't include an ServiceRpc anymore
@@ -353,27 +353,27 @@ def test_replace_dependencies_args_and_kwargs(container_factory,
 
     # verify that the fake dependency collected calls
     msg = "msg"
-    with ServiceRpcClient("service", rabbit_config) as service_proxy:
-        service_proxy.method(msg)
+    with ServiceRpcClient("service", rabbit_config) as service_client:
+        service_client.method(msg)
 
-    assert fake_foo_proxy.processed == [msg]
-    assert mock_bar_proxy.bar.call_count == 1
-    assert mock_baz_proxy.baz.call_count == 1
+    assert fake_foo_client.processed == [msg]
+    assert mock_bar_client.bar.call_count == 1
+    assert mock_baz_client.baz.call_count == 1
 
 
 def test_replace_dependencies_in_both_args_and_kwargs_error(container_factory,
                                                             rabbit_config):
     class Service(object):
         name = "service"
-        foo_proxy = ServiceRpc("foo_service")
-        bar_proxy = ServiceRpc("bar_service")
-        baz_proxy = ServiceRpc("baz_service")
+        foo_client = ServiceRpc("foo_service")
+        bar_client = ServiceRpc("bar_service")
+        baz_client = ServiceRpc("baz_service")
 
     container = container_factory(Service, rabbit_config)
 
     with pytest.raises(RuntimeError) as exc:
         replace_dependencies(
-            container, 'bar_proxy', 'foo_proxy', foo_proxy='foo'
+            container, 'bar_client', 'foo_client', foo_client='foo'
         )
     assert "Cannot replace the same dependency" in str(exc)
 
@@ -382,7 +382,7 @@ def test_replace_non_dependency(container_factory, rabbit_config):
 
     class Service(object):
         name = "service"
-        proxy = ServiceRpc("foo_service")
+        client = ServiceRpc("foo_service")
 
         @rpc
         def method(self):
@@ -404,13 +404,13 @@ def test_replace_dependencies_container_already_started(container_factory,
 
     class Service(object):
         name = "service"
-        proxy = ServiceRpc("foo_service")
+        client = ServiceRpc("foo_service")
 
     container = container_factory(Service, rabbit_config)
     container.start()
 
     with pytest.raises(RuntimeError):
-        replace_dependencies(container, "proxy")
+        replace_dependencies(container, "client")
 
 
 def test_restrict_entrypoints(container_factory, rabbit_config):
@@ -436,9 +436,9 @@ def test_restrict_entrypoints(container_factory, rabbit_config):
     container.start()
 
     # verify the rpc entrypoint on handler_one is disabled
-    with ServiceRpcClient("service", rabbit_config) as service_proxy:
+    with ServiceRpcClient("service", rabbit_config) as service_client:
         with pytest.raises(MethodNotFound) as exc_info:
-            service_proxy.handler_one("msg")
+            service_client.handler_one("msg")
         assert str(exc_info.value) == "handler_one"
 
     # dispatch an event to handler_two


### PR DESCRIPTION
As discussed [on the forum](https://discourse.nameko.io/t/non-persistent-clusterrpcproxy/350/7).

A dynamic RPC proxy DependencyProvider has been requested several times before, and the refactor landing in the v3.x release makes it much easier to provide.

This change simply makes the `target_service` optional when instantiating the `RpcProxy`. 