### PR TITLE
Updated Support to go to https://discourse.nameko.io/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Getting Started
 Support
 -------
 
-For help, comments or questions, please go to <https://discourse.nameko.io/>. The old mailing list on google groups can be found here - `mailing list <https://groups.google.com/forum/#!forum/nameko-dev>`_ on google groups.
+For help, comments or questions, please go to <https://discourse.nameko.io/>.
 
 
 Contribute

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,7 @@ Getting Started
 Support
 -------
 
-For help, comments or questions, please use the `mailing list
-<https://groups.google.com/forum/#!forum/nameko-dev>`_ on google groups.
+For help, comments or questions, please go to <https://discourse.nameko.io/>. The old mailing list on google groups can be found here - `mailing list <https://groups.google.com/forum/#!forum/nameko-dev>`_ on google groups.
 
 
 Contribute


### PR DESCRIPTION
Pointing to the new discussion forum rather than google groups. Keeping the google group line still there in case the old Q&A knowledge base hasn't been migrated to https://discourse.nameko.io/. Cheers