### PR TITLE
Compat fixes

### DIFF
--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -128,7 +128,10 @@ class Consumer(Entrypoint):
 
     consumer_cls = ConsumerCore
 
-    def __init__(self, queue, requeue_on_error=False, **consumer_options):
+    def __init__(
+        self, queue, requeue_on_error=False,
+        expected_exceptions=(), sensitive_arguments=(), **consumer_options
+    ):
         """
         Decorates a method as a message consumer.
 
@@ -158,8 +161,11 @@ class Consumer(Entrypoint):
         self.queue = queue
         self.requeue_on_error = requeue_on_error
         self.consumer_options = consumer_options
-        # TODO it's bad that we eat all the keyword arguments as consumer opts
-        super(Consumer, self).__init__()
+        # TODO it's bad that we eat all the remaining keyword arguments as consumer opts
+        super(Consumer, self).__init__(
+            expected_exceptions=expected_exceptions,
+            sensitive_arguments=sensitive_arguments
+        )
 
     @property
     def amqp_uri(self):

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -281,5 +281,5 @@ class ServiceRpcClient(ClusterRpcClient):
         self.client = getattr(self.client, service_name)
 
 
-ClusterRpcClient = ClusterRpcClient  # backwards compat
-ServiceRpcClient = ServiceRpcClient  # backwards compat
+ClusterRpcProxy = ClusterRpcClient  # backwards compat
+ServiceRpcProxy = ServiceRpcClient  # backwards compat

--- a/nameko/timer.py
+++ b/nameko/timer.py
@@ -13,7 +13,7 @@ _log = getLogger(__name__)
 
 
 class Timer(Entrypoint):
-    def __init__(self, interval):
+    def __init__(self, interval, **kwargs):
         """
         Timer entrypoint implementation. Fires every :attr:`self.interval`
         seconds.
@@ -35,6 +35,7 @@ class Timer(Entrypoint):
         self.interval = interval
         self.should_stop = Event()
         self.gt = None
+        super(Timer, self).__init__(**kwargs)
 
     def start(self):
         _log.debug('starting %s', self)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ universal = 1
 
 [flake8]
 ignore =
-max-line-length = 79
+max-line-length = 88
 exclude = test/nameko_doc/example/*


### PR DESCRIPTION
While testing [nameko-amqp-retry](https://github.com/nameko/nameko-amqp-retry) against the v3 pre-release, I discovered two compatibility issues:

1. A typo in the backwards compat shims in `nameko.standalone.rpc` (45034c1)
2. `expected_exceptions` and `sensitive_arguments` were swallowed by the `Consumer` (720cdc3)

c7a7ac2 adds tests to _all_ built-in entrypoints verifying that `expected_exceptions` and `sensitive_arguments` can be passed.  6768d1a fixes the `Timer` implementation, which did not accept them.