### PR TITLE
Exceptions raised in shell will not be caught when not in TTY

### DIFF
--- a/nameko/cli/code.py
+++ b/nameko/cli/code.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from code import InteractiveConsole
 
 

--- a/nameko/cli/code.py
+++ b/nameko/cli/code.py
@@ -1,0 +1,36 @@
+from code import InteractiveConsole
+
+
+class RaisingInteractiveConsole(InteractiveConsole):
+    """ Custom InterativeConsole class that allows raising exception if needed.
+    """
+
+    def __init__(
+        self, locals=None, filename="<console>", raise_expections=False
+    ):
+        super(RaisingInteractiveConsole, self).__init__(
+            locals=locals, filename=filename
+        )
+        self.raise_expections = raise_expections
+
+    def runcode(self, code):
+        try:
+            exec(code, self.locals)
+        except SystemExit:
+            raise
+        except:
+            self.showtraceback()
+            if self.raise_expections:
+                raise
+
+
+def interact(banner=None, local=None, raise_expections=False):
+    try:
+        import readline  # noqa: F401
+    except ImportError:
+        pass
+
+    console = RaisingInteractiveConsole(
+        locals=local, raise_expections=raise_expections
+    )
+    console.interact(banner=banner)

--- a/nameko/cli/commands.py
+++ b/nameko/cli/commands.py
@@ -130,7 +130,8 @@ class Shell(Command):
             help='RabbitMQ broker url')
         parser.add_argument(
             '--interface', choices=cls.SHELLS,
-            help='Specify an interactive interpreter interface.')
+            help='Specify an interactive interpreter interface.'
+                 ' (Ignored if not in TTY mode)')
         parser.add_argument(
             '--config', default='',
             help='The YAML configuration file')

--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -1,10 +1,10 @@
-import code
 import os
 import sys
 from types import ModuleType
 
 import yaml
 
+import nameko.cli.code as code
 from nameko.constants import AMQP_URI_CONFIG_KEY
 from nameko.standalone.events import event_dispatcher
 from nameko.standalone.rpc import ClusterRpcProxy
@@ -27,10 +27,17 @@ class ShellRunner(object):
         embed(banner1=self.banner, user_ns=self.local)
 
     def plain(self):
-        code.interact(banner=self.banner, local=self.local)
+        code.interact(
+            banner=self.banner,
+            local=self.local,
+            raise_expections=not sys.stdin.isatty()
+        )
 
     def start_shell(self, name):
-        available_shells = [name] if name else Shell.SHELLS
+        if not sys.stdin.isatty():
+            available_shells = ['plain']
+        else:
+            available_shells = [name] if name else Shell.SHELLS
 
         # Support the regular Python interpreter startup script if someone
         # is using it.

--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -50,7 +50,7 @@ class ShellRunner(object):
         for name in available_shells:
             try:
                 return getattr(self, name)()
-            except ImportError:
+            except ImportError:  # noqa: F401
                 pass
         self.plain()
 


### PR DESCRIPTION
This PR changes the behaivour of Nameko shell so it doesn't catch exceptions when used in non-TTY mode. A use case when this would be useful is when nameko shell used for cron jobs and you need to know wether the executed command was successful or not. For example after executing the following command:
```sh
$ echo "n.rpc.other_service.foo()" | nameko shell
```
the exit code will be set to 1 if the execution of the remote method failed.