### PR TITLE
Set extra headers for outbound messaging as late as possible

### DIFF
--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -60,8 +60,6 @@ def new_call_id():
 
 class WorkerContext(object):
 
-    _call_id = None
-    _call_id_stack = None
     _parent_call_id_stack = None
 
     def __init__(
@@ -80,33 +78,27 @@ class WorkerContext(object):
         self._parent_call_id_stack = self.data.pop(
             CALL_ID_STACK_CONTEXT_KEY, []
         )
+        self.call_id = self._make_call_id()
+        self.call_id_stack = self._make_call_id_stack()
+        self.data[CALL_ID_STACK_CONTEXT_KEY] = self.call_id_stack
 
-    @property
-    def call_id_stack(self):
-        if self._call_id_stack is None:
-            parent_calls_tracked = config.get(
-                PARENT_CALLS_CONFIG_KEY, DEFAULT_PARENT_CALLS_TRACKED
-            )
-            stack_length = parent_calls_tracked + 1
+        self.context_data = self.data
 
-            self._call_id_stack = deque(maxlen=stack_length)
-            self._call_id_stack.extend(self._parent_call_id_stack)
-            self._call_id_stack.append(self.call_id)
-        return list(self._call_id_stack)
+    def _make_call_id_stack(self):
+        parent_calls_tracked = config.get(
+            PARENT_CALLS_CONFIG_KEY, DEFAULT_PARENT_CALLS_TRACKED
+        )
+        stack_length = parent_calls_tracked + 1
 
-    @property
-    def call_id(self):
-        if self._call_id is None:
-            self._call_id = '{}.{}.{}'.format(
-                self.service_name, self.entrypoint.method_name, new_call_id()
-            )
-        return self._call_id
+        call_id_stack = deque(maxlen=stack_length)
+        call_id_stack.extend(self._parent_call_id_stack)
+        call_id_stack.append(self.call_id)
+        return list(call_id_stack)
 
-    @property
-    def context_data(self):
-        data = self.data.copy()
-        data[CALL_ID_STACK_CONTEXT_KEY] = self.call_id_stack
-        return data
+    def _make_call_id(self):
+        return '{}.{}.{}'.format(
+            self.service_name, self.entrypoint.method_name, new_call_id()
+        )
 
     @property
     def origin_call_id(self):

--- a/nameko/containers.py
+++ b/nameko/containers.py
@@ -82,7 +82,7 @@ class WorkerContext(object):
         self.call_id_stack = self._make_call_id_stack()
         self.data[CALL_ID_STACK_CONTEXT_KEY] = self.call_id_stack
 
-        self.context_data = self.data
+        self.context_data = self.data  # backwards compat
 
     def _make_call_id_stack(self):
         parent_calls_tracked = config.get(

--- a/nameko/events.py
+++ b/nameko/events.py
@@ -86,9 +86,9 @@ class EventDispatcher(Publisher):
     def get_dependency(self, worker_ctx):
         """ Inject a dispatch method onto the service instance
         """
-        extra_headers = encode_to_headers(worker_ctx.context_data)
 
         def dispatch(event_type, event_data):
+            extra_headers = encode_to_headers(worker_ctx.context_data)
             self.publisher.publish(
                 event_data,
                 exchange=self.exchange,

--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -114,9 +114,9 @@ class Publisher(DependencyProvider):
         )
 
     def get_dependency(self, worker_ctx):
-        extra_headers = encode_to_headers(worker_ctx.context_data)
 
         def publish(msg, **kwargs):
+            extra_headers = encode_to_headers(worker_ctx.context_data)
             self.publisher.publish(
                 msg, extra_headers=extra_headers, **kwargs
             )

--- a/nameko/rpc.py
+++ b/nameko/rpc.py
@@ -478,12 +478,13 @@ class Client(object):
 
         # target at construction time
         client = Client(
-            publish, register_for_reply, "target_service", "target_method"
+            publish, register_for_reply, context_data,
+            "target_service", "target_method"
         )
         client(*args, **kwargs)
 
         # equivalent with attribute access
-        client = Client(publish, register_for_reply)
+        client = Client(publish, register_for_reply, context_data)
         client = client.target_service.target_method  # now fully-specified
         client(*args, **kwargs)
 
@@ -497,6 +498,8 @@ class Client(object):
         register_for_reply : callable
             Function to register a new call with a reply listener. Returns
             another function that should be used to retrieve the response.
+        context_data: dict
+            Worker context data to be sent as extra headers
         service_name : str
             Optional target service name, if known
         method_name : str

--- a/test/test_call_id_stack.py
+++ b/test/test_call_id_stack.py
@@ -51,14 +51,14 @@ def test_short_call_stack(container_factory):
     container = container_factory(FooService)
     service = FooService()
 
-    # Trim stack
     many_ids = [str(i) for i in range(100)]
-    context = WorkerContext(
-        container, service, DummyProvider("long"),
-        data={'call_id_stack': many_ids}
-    )
 
     with setup_config({PARENT_CALLS_CONFIG_KEY: 1}):
+        context = WorkerContext(
+            container, service, DummyProvider("long"),
+            data={'call_id_stack': many_ids}
+        )
+        # Trimmed stack
         assert context.call_id_stack == ['99', 'baz.long.0']
 
 

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -108,19 +108,24 @@ def test_publish_custom_headers(mock_container, mock_producer):
         exchange=foobar_ex, declare=[foobar_queue]).bind(container, "publish")
     publisher.setup()
 
-    # test publish
     msg = "msg"
-    headers = {'nameko.language': 'en',
-               'nameko.customheader': 'customvalue',
-               'nameko.call_id_stack': ['srcservice.method.0']}
     service.publish = publisher.get_dependency(worker_ctx)
+
+    # context data changes are reflected up to the point of publishing
+    worker_ctx.data['language'] = 'fr'
+
     service.publish(msg, publish_kwarg="value")
 
     expected_args = ('msg',)
+    expected_headers = {
+        'nameko.language': 'fr',
+        'nameko.customheader': 'customvalue',
+        'nameko.call_id_stack': ['srcservice.method.0'],
+    }
     expected_kwargs = {
         'publish_kwarg': "value",
         'exchange': foobar_ex,
-        'headers': headers,
+        'headers': expected_headers,
         'declare': publisher.declare,
         'retry': publisher.publisher_cls.retry,
         'retry_policy': publisher.publisher_cls.retry_policy,


### PR DESCRIPTION
Allows for in-entrypoint context data updates. This is useful when setting a language for example:
```python

class LanguageContext(DependencyProvider):

    def get_dependency(self, worker_ctx):
        @contextmanager
        def set_language(language):
            original_language = worker_ctx.data.get('language')
            worker_ctx.data['language'] = language
            yield
            worker_ctx.data['language'] = original_language
        return set_language

class ExampleService(object):

    name = 'exampleservice'

    language_context = LanguageContext()

    @rpc
    def greet_in_french(self):
        with self.language_context('fr'):
            return self.example_rpc.say_hello()
```
Another use we have is services signing up outbound calls with its own authentication.

I removed the lazy load and caching of `call_id` and `call_id_stack` of worker context. These properties are super-cheap and most of the time loaded anyway (if entrypoint contains an outbound call, or in logging debug call_id_stack is logged by the container, if tracer is on and so on...)