### PR TITLE
remove brittle assertions on error messages

### DIFF
--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -729,9 +729,8 @@ class TestStandaloneClientDisconnections(object):
     def test_timeout(self, service_rpc, toxiproxy):
         toxiproxy.set_timeout()
 
-        with pytest.raises(OperationalError) as exc_info:
+        with pytest.raises(OperationalError):
             service_rpc.echo(1)
-        assert "Socket closed" in str(exc_info.value)
 
     def test_reuse_when_down(self, service_rpc, toxiproxy):
         """ Verify we detect stale connections.
@@ -745,14 +744,8 @@ class TestStandaloneClientDisconnections(object):
         toxiproxy.disable()
 
         # publisher cannot connect, raises
-        with pytest.raises(IOError) as exc_info:
+        with pytest.raises(IOError):
             service_rpc.echo(2)
-        assert (
-            # expect the write to raise a BrokenPipe or, if it succeeds,
-            # the socket to be closed on the subsequent confirmation read
-            "Broken pipe" in str(exc_info.value) or
-            "Socket closed" in str(exc_info.value)
-        )
 
     def test_reuse_when_recovered(self, service_rpc, toxiproxy):
         """ Verify we detect and recover from stale connections.
@@ -766,14 +759,8 @@ class TestStandaloneClientDisconnections(object):
         toxiproxy.disable()
 
         # publisher cannot connect, raises
-        with pytest.raises(IOError) as exc_info:
+        with pytest.raises(IOError):
             service_rpc.echo(2)
-        assert (
-            # expect the write to raise a BrokenPipe or, if it succeeds,
-            # the socket to be closed on the subsequent confirmation read
-            "Broken pipe" in str(exc_info.value) or
-            "Socket closed" in str(exc_info.value)
-        )
 
         toxiproxy.enable()
 

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -758,10 +758,9 @@ class TestPublisherDisconnections(object):
         with toxiproxy.timeout(500):
 
             payload1 = "payload1"
-            with pytest.raises(OperationalError) as exc_info:  # socket closed
+            with pytest.raises(OperationalError):  # socket closed
                 with entrypoint_hook(publisher_container, 'send') as send:
                     send(payload1)
-            assert "Socket closed" in str(exc_info.value)
 
             assert tracker.call_args_list == [
                 call("send", payload1),
@@ -791,15 +790,9 @@ class TestPublisherDisconnections(object):
 
             # call 2 fails
             payload2 = "payload2"
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 with entrypoint_hook(publisher_container, 'send') as send:
                     send(payload2)
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
             assert tracker.call_args_list == [
                 call("send", payload1),
@@ -831,15 +824,9 @@ class TestPublisherDisconnections(object):
 
             # call 2 fails
             payload2 = "payload2"
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 with entrypoint_hook(publisher_container, 'send') as send:
                     send(payload2)
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
             assert tracker.call_args_list == [
                 call("send", payload1),

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -1434,10 +1434,9 @@ class TestClientDisconnections(object):
     def test_timeout(self, client_container, toxiproxy):
         with toxiproxy.timeout():
 
-            with pytest.raises(OperationalError) as exc_info:
+            with pytest.raises(OperationalError):
                 with entrypoint_hook(client_container, 'echo') as echo:
                     echo(1)
-            assert "Socket closed" in str(exc_info.value)
 
     def test_reuse_when_down(self, client_container, toxiproxy):
         """ Verify we detect stale connections.
@@ -1451,15 +1450,9 @@ class TestClientDisconnections(object):
 
         with toxiproxy.disabled():
 
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 with entrypoint_hook(client_container, 'echo') as echo:
                     echo(2)
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
     def test_reuse_when_recovered(self, client_container, toxiproxy):
         """ Verify we detect and recover from stale connections.
@@ -1473,15 +1466,9 @@ class TestClientDisconnections(object):
 
         with toxiproxy.disabled():
 
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 with entrypoint_hook(client_container, 'echo') as echo:
                     echo(2)
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
         with entrypoint_hook(client_container, 'echo') as echo:
             assert echo(3) == 3
@@ -1627,9 +1614,8 @@ class TestResponderDisconnections(object):
             eventlet.spawn_n(service_rpc.echo, 1)
 
             # the container will raise if the responder cannot reply
-            with pytest.raises(OperationalError) as exc_info:
+            with pytest.raises(OperationalError):
                 container.wait()
-            assert "Socket closed" in str(exc_info.value)
 
             service_rpc.abort()
 
@@ -1647,14 +1633,8 @@ class TestResponderDisconnections(object):
             eventlet.spawn_n(service_rpc.echo, 2)
 
             # the container will raise if the responder cannot reply
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 container.wait()
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
             service_rpc.abort()
 
@@ -1675,14 +1655,8 @@ class TestResponderDisconnections(object):
             eventlet.spawn_n(service_rpc.echo, 2)
 
             # the container will raise if the responder cannot reply
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 container.wait()
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
         # create new container
         replacement_container = container_factory(service_cls)


### PR DESCRIPTION
Many of these already contain a conditional, and pyamwp 2.4.0 changes them again. I don't think it's worth asserting the message contents.