### PR TITLE
Global config improvement

### DIFF
--- a/docs/examples/standalone_events.py
+++ b/docs/examples/standalone_events.py
@@ -1,9 +1,4 @@
-from nameko import config
 from nameko.standalone.events import event_dispatcher
 
-config.setup({
-    'AMQP_URI': AMQP_URI  # e.g. "pyamqp://guest:guest@localhost"
-})
-
-dispatch = event_dispatcher()
+dispatch = event_dispatcher(uri=AMQP_URI)  # e.g. "pyamqp://guest:guest@localhost"
 dispatch("service_a", "event_type", "payløad")

--- a/docs/examples/standalone_rpc.py
+++ b/docs/examples/standalone_rpc.py
@@ -1,10 +1,7 @@
-from nameko import config
 from nameko.standalone.rpc import ClusterRpcClient
 
 
-config.setup({
-    'AMQP_URI': AMQP_URI  # e.g. "pyamqp://guest:guest@localhost"
-})
-
-with ClusterRpcClient() as cluster_rpc:
+with ClusterRpcClient(
+    uri=AMQP_URI  # e.g. "pyamqp://guest:guest@localhost"
+) as cluster_rpc:
     cluster_rpc.service_x.remote_method("hellø")  # "hellø-x-y"

--- a/nameko/__init__.py
+++ b/nameko/__init__.py
@@ -32,11 +32,11 @@ class Config(UserDict):
             def __call__(self, func):
                 @wraps(func)
                 def wrapper(*args, **kwargs):
-                    self.__enter__()
+                    self.start()
                     try:
                         result = func(*args, **kwargs)
                     finally:
-                        self.__exit__(*tuple())
+                        self.stop()
                     return result
                 return wrapper
 
@@ -45,12 +45,18 @@ class Config(UserDict):
                 self.context_data = context_data
 
             def __enter__(self):
+                self.start()
+
+            def __exit__(self, *exc_info):
+                self.stop()
+
+            def start(self):
                 self.original_data = deepcopy(data)
                 if self.clear:
                     data.clear()
                 data.update(self.context_data)
 
-            def __exit__(self, *exc_info):
+            def stop(self):
                 data.clear()
                 data.update(self.original_data)
 

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -107,27 +107,30 @@ def env_var_constructor(loader, node, raw=False):
 
 
 def setup_yaml_parser():
-    yaml.add_constructor('!env_var', env_var_constructor)
-    yaml.add_constructor('!raw_env_var',
-                         partial(env_var_constructor, raw=True))
-    yaml.add_implicit_resolver('!env_var', IMPLICIT_ENV_VAR_MATCHER)
+    yaml.add_constructor('!env_var', env_var_constructor, yaml.UnsafeLoader)
+    yaml.add_constructor(
+        '!raw_env_var', partial(env_var_constructor, raw=True), yaml.UnsafeLoader
+    )
+    yaml.add_implicit_resolver(
+        '!env_var', IMPLICIT_ENV_VAR_MATCHER, Loader=yaml.UnsafeLoader
+    )
 
 
 def load_config(config_path):
+    setup_yaml_parser()
     with open(config_path) as fle:
-        return yaml.load(fle)
+        return yaml.unsafe_load(fle)
 
 
 def parse_config_option(text):
     if '=' in text:
         key, value = text.strip().split('=', 1)
-        return key, yaml.load(value)
+        return key, yaml.safe_load(value)
     else:
         return text, True
 
 
 def setup_config(args):
-    setup_yaml_parser()
     if args.config:
         config.update(load_config(args.config))
     if hasattr(args, "broker") and args.broker:

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -15,7 +15,7 @@ def parse_config_option(text):
     import yaml
     if '=' in text:
         key, value = text.strip().split('=', 1)
-        return key, yaml.load(value)
+        return key, yaml.unsafe_load(value)
     else:
         return text, True
 

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -253,45 +253,72 @@ def get_message_from_queue(amqp_uri):
 
 @pytest.yield_fixture
 def container_factory():
+    import nameko
     from nameko.containers import get_container_cls
 
     all_containers = []
 
-    def make_container(service_cls):
+    def make_container(service_cls, config=None):
+
+        # nameko 2.X backward compatible passing of custom config argument
+        # we apply config patch if a config dictionary is passed to the factory
+        if config:
+            patch = nameko.config.patch(config)
+            patch.start()
+        else:
+            patch = None
 
         container_cls = get_container_cls()
         container = container_cls(service_cls)
-        all_containers.append(container)
+        all_containers.append((container, patch))
         return container
 
     yield make_container
-    for c in all_containers:
+
+    for container, patch in reversed(all_containers):
         try:
-            c.kill()
+            container.kill()
         except:  # pragma: no cover
             pass
+        if patch:
+            patch.stop()
 
 
 @pytest.yield_fixture
 def runner_factory():
+    import collections
+    import nameko
     from nameko.runners import ServiceRunner
 
     all_runners = []
 
     def make_runner(*service_classes):
+
+        # nameko 2.X backward compatible passing of custom config argument
+        # we apply config patch if a config dictionary is passed to the factory
+        if service_classes and isinstance(service_classes[0], collections.Mapping):
+            config = service_classes[0]
+            service_classes = service_classes[1:]
+            patch = nameko.config.patch(config)
+            patch.start()
+        else:
+            patch = None
+
         runner = ServiceRunner()
         for service_cls in service_classes:
             runner.add_service(service_cls)
-        all_runners.append(runner)
+        all_runners.append((runner, patch))
         return runner
 
     yield make_runner
 
-    for r in all_runners:
+    for runner, patch in reversed(all_runners):
         try:
-            r.kill()
+            runner.kill()
         except:  # pragma: no cover
             pass
+        if patch:
+            patch.stop()
 
 
 @pytest.yield_fixture

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -341,7 +341,7 @@ class TestConfigEnvironmentVariables(object):
             for key, val in env_vars.items():
                 os.environ[key] = val
 
-            results = yaml.load(yaml_config)
+            results = yaml.unsafe_load(yaml_config)
             assert results == expected_config
 
     def test_cannot_recurse(self):
@@ -359,7 +359,7 @@ class TestConfigEnvironmentVariables(object):
         with patch.dict('os.environ'):
             os.environ["VAR1"] = "${VAR1}"
 
-            results = yaml.load(yaml_config)
+            results = yaml.unsafe_load(yaml_config)
             assert results == {'FOO': "${VAR1}", 'BAR': [1, 2, 3]}
 
     @pytest.mark.parametrize(('yaml_config', 'env_vars', 'expected_config'), [
@@ -416,7 +416,7 @@ class TestConfigEnvironmentVariables(object):
             for key, val in env_vars.items():
                 os.environ[key] = val
 
-            results = yaml.load(yaml_config)
+            results = yaml.unsafe_load(yaml_config)
             assert results == expected_config
 
     @pytest.mark.parametrize(('yaml_config', 'env_vars', 'expected_config'), [
@@ -456,5 +456,5 @@ class TestConfigEnvironmentVariables(object):
         with patch.dict('os.environ'):
             for key, val in env_vars.items():
                 os.environ[key] = val
-            results = yaml.load(yaml_config)
+            results = yaml.unsafe_load(yaml_config)
             assert results == expected_config

--- a/test/cli/test_show_config.py
+++ b/test/cli/test_show_config.py
@@ -1,9 +1,11 @@
 from textwrap import dedent
 
+import pytest
 from mock import patch
 
 
 @patch('nameko.cli.main.os')
+@pytest.mark.usefixtures("empty_config")
 def test_main(mock_os, tmpdir, capsys, command):
 
     config_file = tmpdir.join('config.yaml')

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -328,14 +328,9 @@ def test_container_factory_with_config_patch_argument():
     from nameko.testing.pytest import (
         container_factory as container_factory_fixture
     )
-    from nameko.testing.services import dummy
 
     class Service(object):
         name = "x"
-
-        @dummy
-        def method(self):
-            return "OK"
 
     assert config['FOO'] == 1
 
@@ -397,27 +392,18 @@ def test_runner_factory(
 
 
 @config.patch({'FOO': 1})
-def test_ruunner_factory_with_config_patch_argument():
+def test_runner_factory_with_config_patch_argument():
 
     from nameko import config
     from nameko.testing.pytest import (
         runner_factory as runner_factory_fixture
     )
-    from nameko.testing.services import dummy
 
     class ServiceX(object):
         name = "x"
 
-        @dummy
-        def method(self):
-            return "OK"
-
     class ServiceY(object):
         name = "y"
-
-        @dummy
-        def method(self):
-            return "OK"
 
     assert config['FOO'] == 1
 

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -321,6 +321,46 @@ def test_container_factory_with_custom_container_cls(testdir, plugin_options):
     assert result.ret == 0
 
 
+@config.patch({'FOO': 1})
+def test_container_factory_with_config_patch_argument():
+
+    from nameko import config
+    from nameko.testing.pytest import (
+        container_factory as container_factory_fixture
+    )
+    from nameko.testing.services import dummy
+
+    class Service(object):
+        name = "x"
+
+        @dummy
+        def method(self):
+            return "OK"
+
+    assert config['FOO'] == 1
+
+    container_factory_fixture = container_factory_fixture()
+
+    container_factory = next(container_factory_fixture)
+
+    assert config['FOO'] == 1
+
+    container_factory(Service, {'FOO': 2})
+
+    assert config['FOO'] == 2
+
+    container_factory(Service, {'FOO': 3})
+
+    assert config['FOO'] == 3
+
+    try:
+        next(container_factory_fixture)
+    except StopIteration:
+        pass
+
+    assert config['FOO'] == 1
+
+
 @pytest.mark.usefixtures("rabbit_config")
 def test_runner_factory(
     testdir, plugin_options, get_vhost, rabbit_manager
@@ -354,6 +394,53 @@ def test_runner_factory(
 
     vhost = get_vhost(config['AMQP_URI'])
     assert get_rabbit_connections(vhost, rabbit_manager) == []
+
+
+@config.patch({'FOO': 1})
+def test_ruunner_factory_with_config_patch_argument():
+
+    from nameko import config
+    from nameko.testing.pytest import (
+        runner_factory as runner_factory_fixture
+    )
+    from nameko.testing.services import dummy
+
+    class ServiceX(object):
+        name = "x"
+
+        @dummy
+        def method(self):
+            return "OK"
+
+    class ServiceY(object):
+        name = "y"
+
+        @dummy
+        def method(self):
+            return "OK"
+
+    assert config['FOO'] == 1
+
+    runner_factory_fixture = runner_factory_fixture()
+
+    runner_factory = next(runner_factory_fixture)
+
+    assert config['FOO'] == 1
+
+    runner_factory({'FOO': 2}, ServiceX)
+
+    assert config['FOO'] == 2
+
+    runner_factory({'FOO': 3}, ServiceX, ServiceY)
+
+    assert config['FOO'] == 3
+
+    try:
+        next(runner_factory_fixture)
+    except StopIteration:
+        pass
+
+    assert config['FOO'] == 1
 
 
 @pytest.mark.usefixtures('rabbit_config')


### PR DESCRIPTION
Nameko 2.X backward compatible passing of custom config arguments to `container_factory` and `runner_factory` test helpers. Config patch is applied if a config dictionary is passed to these factories.
