### PR TITLE
Deprecation warnings

### DIFF
--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -42,10 +42,10 @@ class HeaderEncoder(object):
         data = worker_ctx.context_data
 
         if None in data.values():
-            _log.warn(
+            warnings.warn(
                 'Attempted to publish unserialisable header value. '
                 'Headers with a value of `None` will be dropped from '
-                'the payload. %s', data)
+                'the payload.', UserWarning)
 
         headers = {self._get_header_name(key): value
                    for key, value in data.items()

--- a/nameko/standalone/events.py
+++ b/nameko/standalone/events.py
@@ -12,8 +12,8 @@ def get_event_exchange(service_name):
     """
     exchange_name = "{}.events".format(service_name)
     exchange = Exchange(
-        exchange_name, type='topic', durable=True, auto_delete=True,
-        delivery_mode=PERSISTENT)
+        exchange_name, type='topic', durable=True, delivery_mode=PERSISTENT
+    )
 
     return exchange
 

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -86,12 +86,6 @@ def pytest_configure(config):
         debug.hub_blocking_detection(True)
 
 
-@pytest.fixture(autouse=True)
-def always_warn_for_deprecation():
-    import warnings
-    warnings.simplefilter('always', DeprecationWarning)
-
-
 @pytest.fixture
 def empty_config():
     return {}

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,7 @@ universal = 1
 ignore =
 max-line-length = 79
 exclude = test/nameko_doc/example/*
+
+[tool:pytest]
+filterwarnings =
+    ignore::DeprecationWarning:kombu.mixins

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,3 @@ universal = 1
 ignore =
 max-line-length = 79
 exclude = test/nameko_doc/example/*
-
-[tool:pytest]
-filterwarnings =
-    ignore::DeprecationWarning:kombu.mixins:

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ exclude = test/nameko_doc/example/*
 
 [tool:pytest]
 filterwarnings =
-    modules:ignore::DeprecationWarning:kombu.mixins:
+    ignore::DeprecationWarning:kombu.mixins:

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,7 @@ universal = 1
 ignore =
 max-line-length = 79
 exclude = test/nameko_doc/example/*
+
+[tool:pytest]
+filterwarnings =
+    modules:ignore::DeprecationWarning:kombu.mixins:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [flake8]
 ignore =
-max-line-length = 79
+max-line-length = 88
 exclude = test/nameko_doc/example/*
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
             "pylint==1.7.1",
             "pytest==4.3.1",
             "pytest-cov==2.5.1",
-            "pytest-timeout==1.3.0",
+            "pytest-timeout==1.3.3",
             "requests==2.19.1",
             "urllib3==1.23",
             "websocket-client==0.48.0",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
             "pycodestyle==2.3.1",
             "pyflakes==1.5.0",
             "pylint==1.7.1",
-            "pytest==3.6.3",
+            "pytest==4.3.1",
             "pytest-cov==2.5.1",
             "pytest-timeout==1.3.0",
             "requests==2.19.1",

--- a/test/amqp/test_publish.py
+++ b/test/amqp/test_publish.py
@@ -146,6 +146,7 @@ class TestPublisher(object):
         message = get_message_from_queue(queue.name)
         assert message.properties[option] == expected
 
+    @pytest.mark.filterwarnings("ignore:Mandatory delivery:UserWarning")
     def test_confirms(self, amqp_uri, publisher):
         publisher.mandatory = True
 

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -655,9 +655,8 @@ class TestStandaloneProxyDisconnections(object):
     def test_timeout(self, service_rpc, toxiproxy):
         toxiproxy.set_timeout()
 
-        with pytest.raises(OperationalError) as exc_info:
+        with pytest.raises(OperationalError):
             service_rpc.echo(1)
-        assert "Socket closed" in str(exc_info.value)
 
     def test_reuse_when_down(self, service_rpc, toxiproxy):
         """ Verify we detect stale connections.
@@ -671,14 +670,8 @@ class TestStandaloneProxyDisconnections(object):
         toxiproxy.disable()
 
         # publisher cannot connect, raises
-        with pytest.raises(IOError) as exc_info:
+        with pytest.raises(IOError):
             service_rpc.echo(2)
-        assert (
-            # expect the write to raise a BrokenPipe or, if it succeeds,
-            # the socket to be closed on the subsequent confirmation read
-            "Broken pipe" in str(exc_info.value) or
-            "Socket closed" in str(exc_info.value)
-        )
 
     def test_reuse_when_recovered(self, service_rpc, toxiproxy):
         """ Verify we detect and recover from stale connections.
@@ -692,14 +685,8 @@ class TestStandaloneProxyDisconnections(object):
         toxiproxy.disable()
 
         # publisher cannot connect, raises
-        with pytest.raises(IOError) as exc_info:
+        with pytest.raises(IOError):
             service_rpc.echo(2)
-        assert (
-            # expect the write to raise a BrokenPipe or, if it succeeds,
-            # the socket to be closed on the subsequent confirmation read
-            "Broken pipe" in str(exc_info.value) or
-            "Socket closed" in str(exc_info.value)
-        )
 
         toxiproxy.enable()
 

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -765,9 +765,8 @@ class TestStandaloneProxyConsumerDisconnections(object):
     def test_timeout(self, service_rpc, toxiproxy):
         with toxiproxy.timeout(stream="downstream"):
 
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 service_rpc.echo(1)
-            assert "Socket closed" in str(exc_info.value)
 
     def test_reuse_when_down(self, service_rpc, toxiproxy):
         assert service_rpc.echo(1) == 1

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -595,6 +595,7 @@ def test_consumer_replacing(container_factory, rabbit_manager, rabbit_config):
 
 
 @skip_if_no_toxiproxy
+@pytest.mark.filterwarnings("ignore:Mandatory delivery:UserWarning")
 class TestStandaloneProxyDisconnections(object):
 
     @pytest.fixture(autouse=True)

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 import pytest
-from mock import ANY, Mock, call
+from mock import Mock, call
 
 from nameko.extensions import DependencyProvider, Entrypoint
 from nameko.testing.services import dummy, entrypoint_hook, once

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 import pytest
-from mock import ANY, Mock, call, patch
+from mock import ANY, Mock, call
 
 from nameko.extensions import DependencyProvider, Entrypoint
 from nameko.testing.services import dummy, entrypoint_hook, once
@@ -12,12 +12,6 @@ from nameko.utils import REDACTED, get_redacted_args
 @pytest.fixture
 def tracker():
     return Mock()
-
-
-@pytest.yield_fixture
-def warnings():
-    with patch('nameko.extensions.warnings') as patched:
-        yield patched
 
 
 class TestDecorator(object):
@@ -170,9 +164,7 @@ class TestSensitiveArguments(object):
             'c': 'C'
         }
 
-    def test_sensitive_variables_backwards_compat(
-        self, container_factory, warnings
-    ):
+    def test_sensitive_variables_backwards_compat(self, container_factory):
 
         class Service(object):
             name = "service"
@@ -181,8 +173,8 @@ class TestSensitiveArguments(object):
             def method(self, a, b, c):
                 pass  # pragma: no cover
 
-        container = container_factory(Service, {})
-        entrypoint = get_extension(container, Entrypoint)
+        with pytest.deprecated_call():
+            container = container_factory(Service, {})
 
+        entrypoint = get_extension(container, Entrypoint)
         assert entrypoint.sensitive_arguments == ("a", "b.x[0]", "b.x[2]")
-        assert warnings.warn.call_args == call(ANY, DeprecationWarning)

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -164,6 +164,7 @@ class TestSensitiveArguments(object):
             'c': 'C'
         }
 
+    @pytest.mark.filterwarnings("ignore:The `sensitive_variables`:DeprecationWarning")
     def test_sensitive_variables_backwards_compat(self, container_factory):
 
         class Service(object):

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -248,6 +248,7 @@ def test_publish_custom_headers(
     ]
 
 
+@pytest.mark.filterwarnings("ignore:Attempted to publish unserialisable`:UserWarning")
 def test_header_encoder(empty_config):
 
     context_data = {

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -150,6 +150,7 @@ def test_publish_to_exchange(
 
 
 @pytest.mark.usefixtures("predictable_call_ids")
+@pytest.mark.filterwarnings("ignore:The signature of `Publisher`:DeprecationWarning")
 def test_publish_to_queue(
     patch_maybe_declare, mock_producer, mock_channel, mock_container
 ):
@@ -215,7 +216,7 @@ def test_publish_custom_headers(
         container, service, DummyProvider('method'), data=ctx_data
     )
 
-    publisher = Publisher(queue=foobar_queue).bind(container, "publish")
+    publisher = Publisher(exchange=foobar_ex).bind(container, "publish")
     publisher.setup()
 
     # test publish
@@ -315,7 +316,7 @@ def test_publish_to_rabbit(rabbit_manager, rabbit_config, mock_container):
     )
 
     publisher = Publisher(
-        exchange=foobar_ex, queue=foobar_queue
+        exchange=foobar_ex, declare=[foobar_queue]
     ).bind(container, "publish")
 
     publisher.setup()
@@ -362,7 +363,7 @@ def test_unserialisable_headers(rabbit_manager, rabbit_config, mock_container):
     )
 
     publisher = Publisher(
-        exchange=foobar_ex, queue=foobar_queue).bind(container, "publish")
+        exchange=foobar_ex, declare=[foobar_queue]).bind(container, "publish")
 
     publisher.setup()
     publisher.start()
@@ -1151,13 +1152,12 @@ class TestConfigurability(object):
         worker_ctx.context_data = {}
 
         exchange = Mock()
-        queue = Mock()
 
         instantiation_value = [Mock()]
         publish_value = [Mock()]
 
         publisher = Publisher(
-            exchange=exchange, queue=queue, **{'declare': instantiation_value}
+            exchange=exchange, **{'declare': instantiation_value}
         ).bind(mock_container, "publish")
         publisher.setup()
 
@@ -1165,12 +1165,12 @@ class TestConfigurability(object):
 
         publish("payload")
         assert producer.publish.call_args[1]['declare'] == (
-            instantiation_value + [exchange, queue]
+            instantiation_value + [exchange]
         )
 
         publish("payload", declare=publish_value)
         assert producer.publish.call_args[1]['declare'] == (
-            instantiation_value + [exchange, queue] + publish_value
+            instantiation_value + [exchange] + publish_value
         )
 
     def test_use_confirms(self, mock_container, get_producer):

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -369,8 +369,11 @@ def test_unserialisable_headers(rabbit_manager, rabbit_config, mock_container):
     publisher.setup()
     publisher.start()
 
-    service.publish = publisher.get_dependency(worker_ctx)
+    with pytest.warns(UserWarning):
+        service.publish = publisher.get_dependency(worker_ctx)
+
     service.publish("msg")
+
     messages = rabbit_manager.get_messages(vhost, foobar_queue.name)
 
     assert messages[0]['properties']['headers'] == {

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -347,6 +347,7 @@ def test_publish_to_rabbit(rabbit_manager, rabbit_config, mock_container):
 
 
 @pytest.mark.usefixtures("predictable_call_ids")
+@pytest.mark.filterwarnings("ignore:Attempted to publish unserialisable`:UserWarning")
 def test_unserialisable_headers(rabbit_manager, rabbit_config, mock_container):
 
     vhost = rabbit_config['vhost']

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -872,10 +872,9 @@ class TestPublisherDisconnections(object):
         with toxiproxy.timeout(500):
 
             payload1 = "payload1"
-            with pytest.raises(OperationalError) as exc_info:  # socket closed
+            with pytest.raises(OperationalError):  # socket closed
                 with entrypoint_hook(publisher_container, 'send') as send:
                     send(payload1)
-            assert "Socket closed" in str(exc_info.value)
 
             assert tracker.call_args_list == [
                 call("send", payload1),
@@ -905,15 +904,9 @@ class TestPublisherDisconnections(object):
 
             # call 2 fails
             payload2 = "payload2"
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 with entrypoint_hook(publisher_container, 'send') as send:
                     send(payload2)
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
             assert tracker.call_args_list == [
                 call("send", payload1),
@@ -945,15 +938,9 @@ class TestPublisherDisconnections(object):
 
             # call 2 fails
             payload2 = "payload2"
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 with entrypoint_hook(publisher_container, 'send') as send:
                     send(payload2)
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
             assert tracker.call_args_list == [
                 call("send", payload1),

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -1240,10 +1240,9 @@ class TestProxyDisconnections(object):
     def test_timeout(self, client_container, toxiproxy):
         with toxiproxy.timeout():
 
-            with pytest.raises(OperationalError) as exc_info:
+            with pytest.raises(OperationalError):
                 with entrypoint_hook(client_container, 'echo') as echo:
                     echo(1)
-            assert "Socket closed" in str(exc_info.value)
 
     def test_reuse_when_down(self, client_container, toxiproxy):
         """ Verify we detect stale connections.
@@ -1257,15 +1256,9 @@ class TestProxyDisconnections(object):
 
         with toxiproxy.disabled():
 
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 with entrypoint_hook(client_container, 'echo') as echo:
                     echo(2)
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
     def test_reuse_when_recovered(self, client_container, toxiproxy):
         """ Verify we detect and recover from stale connections.
@@ -1279,15 +1272,9 @@ class TestProxyDisconnections(object):
 
         with toxiproxy.disabled():
 
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 with entrypoint_hook(client_container, 'echo') as echo:
                     echo(2)
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
         with entrypoint_hook(client_container, 'echo') as echo:
             assert echo(3) == 3
@@ -1437,9 +1424,8 @@ class TestResponderDisconnections(object):
             eventlet.spawn_n(service_rpc.echo, 1)
 
             # the container will raise if the responder cannot reply
-            with pytest.raises(OperationalError) as exc_info:
+            with pytest.raises(OperationalError):
                 container.wait()
-            assert "Socket closed" in str(exc_info.value)
 
             service_rpc.abort()
 
@@ -1457,14 +1443,8 @@ class TestResponderDisconnections(object):
             eventlet.spawn_n(service_rpc.echo, 2)
 
             # the container will raise if the responder cannot reply
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 container.wait()
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
             service_rpc.abort()
 
@@ -1485,14 +1465,8 @@ class TestResponderDisconnections(object):
             eventlet.spawn_n(service_rpc.echo, 2)
 
             # the container will raise if the responder cannot reply
-            with pytest.raises(IOError) as exc_info:
+            with pytest.raises(IOError):
                 container.wait()
-            assert (
-                # expect the write to raise a BrokenPipe or, if it succeeds,
-                # the socket to be closed on the subsequent confirmation read
-                "Broken pipe" in str(exc_info.value) or
-                "Socket closed" in str(exc_info.value)
-            )
 
         # create new container
         replacement_container = container_factory(service_cls, rabbit_config)

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -1156,6 +1156,7 @@ class TestRpcConsumerDisconnections(object):
 
 
 @skip_if_no_toxiproxy
+@pytest.mark.filterwarnings("ignore:Mandatory delivery:UserWarning")
 class TestProxyDisconnections(object):
     """ Test and demonstrate behaviour under poor network conditions.
 
@@ -1303,6 +1304,7 @@ class TestProxyDisconnections(object):
 
 
 @skip_if_no_toxiproxy
+@pytest.mark.filterwarnings("ignore:Mandatory delivery:UserWarning")
 class TestResponderDisconnections(object):
     """ Test and demonstrate behaviour under poor network conditions.
 

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -41,7 +41,7 @@ class TestOptions(object):
         options = (
             ("--amqp-uri", 'amqp://localhost:5672/vhost'),
             ("--rabbit-api-uri", 'http://localhost:15672'),
-            ("--amqp-ssl-port", 1234),
+            ("--amqp-ssl-port", '1234'),
         )
 
         testdir.makepyfile(

--- a/test/testing/test_utils.py
+++ b/test/testing/test_utils.py
@@ -184,13 +184,8 @@ def test_wait_for_worker_idle(container_factory, rabbit_config):
 
     max_workers = DEFAULT_MAX_WORKERS
 
-    # TODO: pytest.warns is not supported until pytest >= 2.8.0, whose
-    # `testdir` plugin is not compatible with eventlet on python3 --
-    # see https://github.com/mattbennett/eventlet-pytest-bug
-    with warnings.catch_warnings(record=True) as ws:
+    with pytest.deprecated_call():
         wait_for_worker_idle(container)
-        assert len(ws) == 1
-        assert issubclass(ws[-1].category, DeprecationWarning)
 
     # verify nothing running
     assert container._worker_pool.free() == max_workers

--- a/test/testing/test_utils.py
+++ b/test/testing/test_utils.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 
 import eventlet
 import pytest

--- a/test/testing/test_utils.py
+++ b/test/testing/test_utils.py
@@ -167,6 +167,7 @@ def test_reset_rabbit_connection_errors():
         reset_rabbit_connections("vhost_name", rabbit_manager)
 
 
+@pytest.mark.filterwarnings("ignore:`wait_for_worker_idle` is :DeprecationWarning")
 def test_wait_for_worker_idle(container_factory, rabbit_config):
 
     event = Event()


### PR DESCRIPTION
Some changes that reduce the warnings shown after running tests:

1. Stop setting the deprecated `auto_delete` flag on the Event exchange
2. Stop forcing all `DeprecationWarning`s to be logged
3. Ignore all `DeprecationWarning`s coming from libraries we cannot control
4. Detect `DeprecationWarning`s we do care about with `pytest.deprecated_call`
5. Silence any warnings that we intentionally trigger in the test suite. 

Required bumping pytest to a recent version.

Compare the build logs of https://travis-ci.org/nameko/nameko/jobs/515280316 (this branch) to https://travis-ci.org/nameko/nameko/jobs/513850376 (current master)