### PR TITLE
Pytest fixtures Nameko 2.x backward compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .coverage
+.pytest_cache
 *.pyc
 _py_cache
 docs/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ services:
   - docker
 
 before_install:
-    # start rabbitmq, grab client ssl certs
-    - docker run -d --rm -p 15672:15672 -p 5672:5672 -p 5671:5671 --name nameko-rabbitmq nameko/nameko-rabbitmq:3.6.6
-    - docker cp nameko-rabbitmq:/srv/ssl certs
+    - make rabbitmq-container
     # install toxiproxy
     - mkdir $PWD/bin
     - wget -O $PWD/bin/toxiproxy-server https://github.com/Shopify/toxiproxy/releases/download/v2.0.0/toxiproxy-server-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,7 @@ spelling:
 
 linkcheck:
 	sphinx-build -W -b linkcheck -d docs/build/doctrees docs docs/build/linkcheck
+
+rabbitmq-container:
+	docker run -d --rm -p 15672:15672 -p 5672:5672 -p 5671:5671 --name nameko-rabbitmq nameko/nameko-rabbitmq:3.6.6
+	docker cp nameko-rabbitmq:/srv/ssl certs

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -96,8 +96,9 @@ def always_warn_for_deprecation():
 
 @pytest.yield_fixture
 def empty_config():
-    with config.patch({}, clear=True):
-        yield
+    conf = {}
+    with config.patch(conf, clear=True):
+        yield conf  # nameko 2.X backward compatible
 
 
 @pytest.yield_fixture
@@ -182,8 +183,9 @@ def rabbit_uri(request, vhost_pipeline):
 
 @pytest.yield_fixture
 def rabbit_config(rabbit_uri):
-    with config.patch({'AMQP_URI': rabbit_uri}):
-        yield
+    conf = {'AMQP_URI': rabbit_uri}
+    with config.patch(conf):
+        yield conf  # nameko 2.X backward compatible
 
 
 @pytest.fixture
@@ -217,7 +219,7 @@ def rabbit_ssl_config(request, rabbit_ssl_uri, rabbit_ssl_options):
     }
 
     with config.patch(conf):
-        yield
+        yield conf  # nameko 2.X backward compatible
 
 
 @pytest.fixture
@@ -340,8 +342,9 @@ def web_config():
 
     port = find_free_port()
 
-    with config.patch({WEB_SERVER_CONFIG_KEY: "127.0.0.1:{}".format(port)}):
-        yield
+    conf = {WEB_SERVER_CONFIG_KEY: "127.0.0.1:{}".format(port)}
+    with config.patch(conf):
+        yield conf  # nameko 2.X backward compatible
 
 
 @pytest.fixture()

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -85,8 +85,7 @@ class TestOptions(object):
 
             from nameko import config
 
-            @pytest.mark.usefixtures("rabbit_ssl_config")
-            def test_ssl_options(request):
+            def test_ssl_options(request, rabbit_ssl_config):
                 assert request.config.getoption('AMQP_SSL_OPTIONS') == [
                     # defaults
                     ('ca_certs', 'certs/cacert.pem'),
@@ -116,6 +115,12 @@ class TestOptions(object):
                     'keyonly': True,
                 }
                 assert config['AMQP_SSL'] == expected_ssl_options
+
+                # nameko 2.X backward compatible
+                assert rabbit_ssl_config == {
+                    'AMQP_SSL': config['AMQP_SSL'],
+                    'AMQP_URI': config['AMQP_URI'],
+                }
             """
         )
         args = []
@@ -130,6 +135,7 @@ class TestOptions(object):
 
 def test_empty_config(empty_config):
     assert config == {}
+    assert empty_config == {}  # nameko 2.X backward compatible
 
 
 def test_rabbit_manager(rabbit_manager):
@@ -165,6 +171,12 @@ def test_amqp_uri(testdir):
         "--amqp-uri", amqp_uri
     )
     assert result.ret == 0
+
+
+def test_rabbit_config(rabbit_config, rabbit_uri):
+    conf = {'AMQP_URI': rabbit_uri}
+    assert config['AMQP_URI'] == rabbit_uri
+    assert rabbit_config == conf  # nameko 2.X backward compatible
 
 
 class TestGetMessageFromQueue(object):
@@ -462,13 +474,15 @@ def test_predictable_call_ids(runner_factory):
     assert call_ids == ["x.method.1", "y.method.2"]
 
 
-@pytest.mark.usefixtures('web_config')
-def test_web_config():
+def test_web_config(web_config):
     assert WEB_SERVER_CONFIG_KEY in config
 
     bind_address = parse_address(config[WEB_SERVER_CONFIG_KEY])
     sock = socket.socket()
     sock.bind(bind_address)
+
+    # nameko 2.X backward compatible
+    assert web_config == {WEB_SERVER_CONFIG_KEY: config[WEB_SERVER_CONFIG_KEY]}
 
 
 @pytest.mark.usefixtures('web_config')


### PR DESCRIPTION
Following up on the work done here https://github.com/nameko/nameko/pull/610, this would make the following fixtures backward compatible with Nameko `2.x`:

* `empty_config`
* `rabbit_config`
* `rabbit_ssl_config`
* `web_config`

Migrating Nameko services to `v3.0.0` it's easier now, since there's no need to keep backward compatibilitty in the tests with previous Nameko versions. However, trying to test Nameko extensions with both Nameko 2.x and 3.x is not trivial at the moment.

I'm trying to do that for a few dependency providers and extensions, in order to make sure they're tested with Nameko 2.x and and the same time compatible with the latest code on `3.0.0-rc`.

By making those fixtures also return the part of the config that they create, we can keep them backward compatible with Nameko `2.x` and testing extensions becomes much easier.

Any suggestions or comments are more than welcome!