### PR TITLE
Rename service name in running command

### DIFF
--- a/nameko/cli/commands.py
+++ b/nameko/cli/commands.py
@@ -102,8 +102,10 @@ class Run(Command):
             ' connected to for an interactive interpreter within the running'
             ' service process using `nameko backdoor`.')
         parser.add_argument(
-            '--cname', default='', type=str,
-            help='Cover service cls name')
+            '--rename', default='', type=str, nargs='+',
+            help='Rename service name, supporting cover origin service name '
+                 'by passing renaming rules in, like "origin_service:target_name".'
+                 'And target name is enough if only one service is started')
 
         return parser
 

--- a/nameko/cli/commands.py
+++ b/nameko/cli/commands.py
@@ -101,6 +101,9 @@ class Run(Command):
             help='Specify a port number to host a backdoor, which can be'
             ' connected to for an interactive interpreter within the running'
             ' service process using `nameko backdoor`.')
+        parser.add_argument(
+            '--cname', default='', type=str,
+            help='Cover service cls name')
 
         return parser
 

--- a/nameko/cli/run.py
+++ b/nameko/cli/run.py
@@ -113,11 +113,11 @@ def setup_backdoor(runner, port):
     return socket, gt
 
 
-def run(services, config, backdoor_port=None, cname=None):
+def run(services, config, backdoor_port=None, rename=None):
     service_runner = ServiceRunner(config)
     for service_cls in services:
-        if cname:
-            setattr(service_cls, "name", cname)
+        if rename and rename.get(service_cls.name):
+            service_cls.name = rename[service_cls.name]
         service_runner.add_service(service_cls)
 
     def shutdown(signum, frame):
@@ -183,4 +183,12 @@ def main(args):
             import_service(path)
         )
 
-    run(services, config, backdoor_port=args.backdoor_port, cname=args.cname)
+    rename = args.rename
+    if len(rename) > 1:
+        rename = dict(map(lambda x: x.split(":", 1), rename))
+    elif len(rename) == 1 and len(services) == 1:
+        rename = {getattr(services[0], "name", None): rename[0]}
+    else:
+        rename = None
+
+    run(services, config, backdoor_port=args.backdoor_port, rename=rename)

--- a/nameko/cli/run.py
+++ b/nameko/cli/run.py
@@ -113,9 +113,11 @@ def setup_backdoor(runner, port):
     return socket, gt
 
 
-def run(services, config, backdoor_port=None):
+def run(services, config, backdoor_port=None, cname=None):
     service_runner = ServiceRunner(config)
     for service_cls in services:
+        if cname:
+            setattr(service_cls, "name", cname)
         service_runner.add_service(service_cls)
 
     def shutdown(signum, frame):
@@ -181,4 +183,4 @@ def main(args):
             import_service(path)
         )
 
-    run(services, config, backdoor_port=args.backdoor_port)
+    run(services, config, backdoor_port=args.backdoor_port, cname=args.cname)

--- a/nameko/cli/run.py
+++ b/nameko/cli/run.py
@@ -184,7 +184,7 @@ def main(args):
         )
 
     rename = args.rename
-    if len(rename) > 1:
+    if len(rename) >= 1 and ":" in rename[0]:
         rename = dict(map(lambda x: x.split(":", 1), rename))
     elif len(rename) == 1 and len(services) == 1:
         rename = {getattr(services[0], "name", None): rename[0]}


### PR DESCRIPTION
This PR add an alternative para in running command to rename service class's name.

why it may be needed: I am working with others on same micro service and sharing same amqp, oftenly we will run service locally in which case service name must be changed to different name before running. And change back before push to svn. It maybe bring some convenience.

