### PR TITLE
fix for test_container_only_killed_once

### DIFF
--- a/test/test_container.py
+++ b/test/test_container.py
@@ -372,9 +372,6 @@ def test_container_only_killed_once(container):
     ) as kill_managed_threads:
 
         with patch.object(container, 'kill', wraps=container.kill) as kill:
-            # insert an eventlet yield into the kill process, otherwise
-            # the container dies before the second exception gets raised
-            kill.side_effect = lambda exc: sleep()
 
             container.start()
 


### PR DESCRIPTION
https://bugs.python.org/issue35330 fixed a bug that we were accidentally exploiting, so the wrapped `container.kill` is not called with mock >= 3.0.0

It turns out that we no longer need the sleep that was being inserted, so simply dropping the `side_effect` fixes the tests with all versions of Mock.