### PR TITLE
Skip ssl tests if certs are not available or ssl port is not open

### DIFF
--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
 
+import os
+from contextlib import closing
+
+import eventlet
 import pytest
 
 from nameko import config
@@ -190,6 +194,13 @@ def rabbit_config(rabbit_uri):
 def rabbit_ssl_options(request):
     ssl_options = request.config.getoption('AMQP_SSL_OPTIONS')
     ssl_options = {key: value for key, value in ssl_options} or True
+
+    for file_key in ['ca_certs', 'certfile', 'keyfile']:
+        filename = ssl_options.get(file_key)
+        if filename and not os.path.isfile(filename):  # pragma: no cover
+            pytest.skip('ssl {} file {} does not exist'
+                        .format(file_key, filename))
+
     return ssl_options
 
 
@@ -204,6 +215,18 @@ def rabbit_ssl_uri(request, rabbit_uri):
             str(uri_parts.port),
             str(amqp_ssl_port))
     ).geturl()
+
+    # the eventlet patched version of socket always returns `None` when calling
+    # connect_ex, so in this case we have to use the original version to check
+    # if the rabbitmq ssl port is open.
+    socket = eventlet.patcher.original('socket')
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        conn_args = (uri_parts.hostname, amqp_ssl_port)
+        ssl_port_open = sock.connect_ex(conn_args) == 0  # pylint: disable=E1101
+        if not ssl_port_open:  # pragma: no cover
+            pytest.skip('SSL port {} on host {} is closed. '
+                        'SSL tests cannot be performed'.format(
+                            amqp_ssl_port, uri_parts.hostname))
 
     return amqp_ssl_uri
 


### PR DESCRIPTION
These are a few possibilities for implementing https://www.notion.so/Skip-RabbitMQ-SSL-tests-if-secure-port-not-available-73a50e2111704b50b01fabfb27683879

1. Check for the cert files and skip if they are not found
2. Check the configured host and check if ssl port is available and skip if it is not

I would say the first is probably simpler and might be enough (considering that if you went through the trouble of copying over the ssl certs you probably also have the correct docker container running), but I thought I'd put all the ideas in here (maybe there's also something completely different I didn't think of).