### PR TITLE
Fix Python 3.7 warning on collections.abc

### DIFF
--- a/nameko/exceptions.py
+++ b/nameko/exceptions.py
@@ -5,6 +5,7 @@ import sys
 
 import six
 
+
 if sys.version_info >= (3, 3):
     from collections.abc import Iterable
 else:

--- a/nameko/exceptions.py
+++ b/nameko/exceptions.py
@@ -1,9 +1,14 @@
 from __future__ import unicode_literals
 
-import collections
 import inspect
+import sys
 
 import six
+
+if sys.version_info >= (3, 3):
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 
 class ExtensionNotFound(AttributeError):
@@ -73,7 +78,7 @@ def safe_for_serialization(value):
             safe_for_serialization(key): safe_for_serialization(val)
             for key, val in six.iteritems(value)
         }
-    if isinstance(value, collections.Iterable):
+    if isinstance(value, Iterable):
         return list(map(safe_for_serialization, value))
 
     try:

--- a/nameko/exceptions.py
+++ b/nameko/exceptions.py
@@ -7,7 +7,7 @@ import six
 
 
 if sys.version_info >= (3, 3):
-    from collections.abc import Iterable
+    from collections.abc import Iterable  # pylint: disable=E0611,E0401
 else:
     from collections import Iterable
 

--- a/nameko/exceptions.py
+++ b/nameko/exceptions.py
@@ -6,9 +6,9 @@ import sys
 import six
 
 
-if sys.version_info >= (3, 3):
+if sys.version_info >= (3, 3):  # pragma: no cover
     from collections.abc import Iterable  # pylint: disable=E0611,E0401
-else:
+else:  # pragma: no cover
     from collections import Iterable
 
 


### PR DESCRIPTION
Python 3.3 moved the ABC's from `collections` into `collections.abc`, Python 3.7 deprecates the use of them at the original location. Hence in my tests I saw Pytest gathering the warnings emitted from `collections.abc`:

```
tests/integration/test_nameko.py::test_server_error
  /private/tmp/tox/py37-django22/lib/python3.7/site-packages/nameko/exceptions.py:76: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if isinstance(value, collections.Iterable):
```

This PR fixes it to use a conditional import based on the Python version.

I see Python 3.7 will be tested in #644, but this fix isn't in there.