### PR TITLE
Click config fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
       python: 3.6
       env: TOX_ENV=py36-static
     - stage: docs
-      python: 2.7
+      python: 3.6
       env: TOX_ENV=docs
     - stage: examples
       python: 2.7

--- a/nameko/__init__.py
+++ b/nameko/__init__.py
@@ -80,11 +80,11 @@ The config can be used straight on service definition level, e.g.::
 
         @consume(
             queue=Queue(
-                exchange=config.MY_EXCHANGE,
-                routing_key=config.MY_ROUTING_KEY,
-                name=config.MY_QUEUE_NAME
+                exchange=config.get("MY_EXCHANGE"),
+                routing_key=config.get("MY_ROUTING_KEY"),
+                name=config.get("MY_QUEUE_NAME")
             ),
-            prefetch_count=config.MY_CONSUMER_PREFETCH_COUNT
+            prefetch_count=config.get("MY_CONSUMER_PREFETCH_COUNT")
         )
         def consume(self, payload):
             pass

--- a/nameko/cli/click_arguments.py
+++ b/nameko/cli/click_arguments.py
@@ -10,12 +10,6 @@ from functools import partial
 
 import click
 
-from .click_paramtypes import NamekoModuleServicesParamType
-
-
-def flatten_list_of_lists(ctx, param, list_of_lists):
-    return sum(list_of_lists, [])
-
 
 argument_services = partial(
     click.argument,
@@ -23,7 +17,5 @@ argument_services = partial(
     nargs=-1,
     required=True,
     metavar="module[:service class]",
-    # allow import of modules from current dir (manipulate sys.path)
-    type=NamekoModuleServicesParamType(extra_sys_paths=["."]),
-    callback=flatten_list_of_lists,
+    type=str,
 )

--- a/nameko/cli/click_paramtypes.py
+++ b/nameko/cli/click_paramtypes.py
@@ -1,12 +1,8 @@
 """Custom click parameter types used in nameko.
 """
-import sys
-
 import click
 import six
 import yaml
-
-from .utils import import_services
 
 
 class KeyValParamType(click.ParamType):
@@ -50,33 +46,3 @@ class HostPortParamType(click.ParamType):
 
 
 HOST_PORT = HostPortParamType()
-
-
-class NamekoModuleServicesParamType(click.ParamType):
-    """Nameko service(s) specified in nameko compliant module.
-    """
-
-    name = "nameko_module_services"
-
-    def __init__(self, extra_sys_paths=None):
-        """extra_sys_paths: list of paths, which are added to sys.path
-        before iporting services.
-
-        Note: syspath stays modified to preserve predictable environment
-        for running the code.
-        """
-        self.extra_sys_paths = extra_sys_paths or []
-
-    def convert(self, value, param, ctx):
-        try:
-            for path in self.extra_sys_paths:
-                if path not in sys.path:
-                    sys.path.insert(0, path)
-            return import_services(value)
-        except ValueError as exc:
-            templ = "'{value}'. {msg}"
-            args = {"value": value, "msg": str(exc)}
-            self.fail(templ.format(**args), param, ctx)
-
-
-NAMEKO_MODULE_SERVICES = NamekoModuleServicesParamType()

--- a/nameko/cli/run.py
+++ b/nameko/cli/run.py
@@ -1,17 +1,18 @@
 from __future__ import print_function
 
 import eventlet
-
 eventlet.monkey_patch()  # noqa (code before rest of imports)
 
 import errno
 import logging
 import logging.config
 import signal
+import sys
 
 from eventlet import backdoor
 
 from nameko import config
+from nameko.cli.utils import import_services
 from nameko.runners import ServiceRunner
 
 
@@ -37,7 +38,15 @@ def setup_backdoor(runner, backdoor_port):
     return socket, gt
 
 
-def run(services, backdoor_port=None):
+def run(service_modules, backdoor_port=None):
+
+    if "." not in sys.path:
+        sys.path.append(".")
+
+    services = []
+    for path in service_modules:
+        services.extend(import_services(path))
+
     service_runner = ServiceRunner()
     for service_cls in services:
         service_runner.add_service(service_cls)

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -6,7 +6,6 @@ import yaml
 from mock import call, patch
 
 from nameko.cli import cli
-from nameko.cli.utils import import_services
 from nameko.cli.utils.config import ENV_VAR_MATCHER, setup_yaml_parser
 from nameko.exceptions import CommandError, ConfigurationError
 

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -38,7 +38,7 @@ def fake_argv(empty_config):
 
 def test_run():
     define = {"AMQP_URI": "pyamqp://someuser:*****@somehost/"}
-    services = import_services("test.sample:Service")
+    services = ("test.sample:Service",)
     config_file = None
     broker = None
     backdoor_port = None

--- a/test/cli/test_paramtypes.py
+++ b/test/cli/test_paramtypes.py
@@ -1,13 +1,7 @@
-import sys
-
 import click
 import pytest
 
-from nameko.cli.click_paramtypes import (
-    HostPortParamType, KeyValParamType, NamekoModuleServicesParamType
-)
-
-from test.sample import Service
+from nameko.cli.click_paramtypes import HostPortParamType, KeyValParamType
 
 
 @pytest.mark.parametrize(
@@ -41,57 +35,6 @@ def test_key_value(value, expected):
 )
 def test_host_port(value, expected):
     ctype = HostPortParamType()
-    if isinstance(expected, Exception):
-        with pytest.raises(expected.__class__) as exc_info:
-            result = ctype.convert(value, None, None)
-        assert exc_info.value.message == expected.message
-    else:
-        result = ctype.convert(value, None, None)
-        assert result == expected
-
-
-@pytest.mark.parametrize(
-    "value,expected",
-    [
-        ("test.sample", [Service]),
-        ("test.sample:Service", [Service]),
-        # py2.7 version (skip for py3.x)
-        pytest.param(
-            "test.missing_module",
-            click.exceptions.BadParameter(
-                "'test.missing_module'. No module named missing_module"
-            ),
-            marks=pytest.mark.skipif(
-                sys.version_info >= (3, 0),
-                reason="This exception texting is py2.x specific",
-            ),
-        ),
-        # py3.x version (skip for py2.x)
-        pytest.param(
-            "test.missing_module",
-            click.exceptions.BadParameter(
-                "'test.missing_module'. No module named 'test.missing_module'"
-            ),
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 0),
-                reason="This exception texting is py3.x specific",
-            ),
-        ),
-        pytest.param(
-            "test.sample:MissingService",
-            click.exceptions.BadParameter(
-                "'test.sample:MissingService'. "
-                "Failed to find service class 'MissingService' in module 'test.sample'"
-            ),
-        ),
-        pytest.param(
-            "test.not_importable",
-            click.exceptions.BadParameter("'test.not_importable'. "),
-        ),
-    ],
-)
-def test_nameko_module_services(value, expected):
-    ctype = NamekoModuleServicesParamType(["."])
     if isinstance(expected, Exception):
         with pytest.raises(expected.__class__) as exc_info:
             result = ctype.convert(value, None, None)

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import eventlet
 import pytest
-from mock import call, patch
+from mock import patch
 
 from nameko import config
 from nameko.cli.run import run, setup_backdoor

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import eventlet
 import pytest
-from mock import patch
+from mock import call, patch
 
 from nameko import config
 from nameko.cli.run import run, setup_backdoor
@@ -270,7 +270,7 @@ def test_stopping(rabbit_config):
             KeyboardInterrupt,
             None,  # second wait, after stop() which returns normally
         ]
-        gt = eventlet.spawn(run, [Service])
+        gt = eventlet.spawn(run, ["test.sample"])
         gt.wait()
         # should complete
 
@@ -287,7 +287,7 @@ def test_stopping_twice(rabbit_config):
             runner.stop.side_effect = KeyboardInterrupt
             runner.kill.return_value = None
 
-            gt = eventlet.spawn(run, [Service])
+            gt = eventlet.spawn(run, ["test.sample"])
             gt.wait()
 
 
@@ -301,7 +301,7 @@ def test_os_error_for_signal(rabbit_config):
         # don't actually start the service -- we're not firing a real signal
         # so the signal handler won't stop it again
         with patch.object(ServiceRunner, "start"):
-            gt = eventlet.spawn(run, [Service])
+            gt = eventlet.spawn(run, ["test.sample"])
             gt.wait()
         # should complete
 
@@ -316,7 +316,7 @@ def test_other_errors_propagate(rabbit_config):
         # don't actually start the service -- there's no real OSError that
         # would otherwise kill the whole process
         with patch.object(ServiceRunner, "start"):
-            gt = eventlet.spawn(run, [Service])
+            gt = eventlet.spawn(run, ["test.sample"])
             with pytest.raises(OSError):
                 gt.wait()
 

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import eventlet
 import pytest
-from mock import patch
+from mock import call, patch
 
 from nameko import config
 from nameko.cli.run import run, setup_backdoor
@@ -149,6 +149,20 @@ def test_main_with_logging_config(command, tmpdir):
     gt.wait()
 
     assert "test.sample - INFO - ping!" in capture_file.read()
+
+
+def test_multiple_service_modules(command):
+
+    with patch("nameko.cli.run.main") as run:
+
+        command(
+            "nameko",
+            "run",
+            "test.foo",
+            "test.bar"
+        )
+
+        assert run.call_args_list == [call(("test.foo", "test.bar"), None)]
 
 
 def test_parse_config_before_service_import(command, tmpdir, add_to_sys_path):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import uuid
 from contextlib import contextmanager
+from types import ModuleType
 
 import eventlet
 import pytest
@@ -11,7 +12,6 @@ from kombu.messaging import Queue
 from mock import ANY, patch
 from six.moves import queue
 from six.moves.urllib.parse import urlparse
-from types import ModuleType
 
 from nameko import config
 from nameko.amqp.publish import get_connection

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 import uuid
 from contextlib import contextmanager
-from types import ModuleType
 
 import eventlet
 import pytest
@@ -12,6 +11,7 @@ from kombu.messaging import Queue
 from mock import ANY, patch
 from six.moves import queue
 from six.moves.urllib.parse import urlparse
+from types import ModuleType
 
 from nameko import config
 from nameko.amqp.publish import get_connection
@@ -189,6 +189,18 @@ def fake_module():
     sys.modules[module.__name__] = module
     yield module
     del sys.modules[module.__name__]
+
+
+@pytest.fixture
+def add_to_sys_path():
+
+    @contextmanager
+    def modify_sys_path(path):
+        sys.path.insert(0, path)
+        yield
+        sys.path.remove(path)
+
+    return modify_sys_path
 
 
 @pytest.fixture

--- a/test/not_importable.py
+++ b/test/not_importable.py
@@ -1,1 +1,0 @@
-raise ImportError()


### PR DESCRIPTION
Converting the CLI to click (#620) had an unintended consequence of moving the service import before the config parsing. As a result services could no longer read configuration at import time.

This PR adds a failing test and then the fix. It also adds an extra test for importing multiple services at once, and updates one broken example in a docstring.
