### PR TITLE
Add --version CLI flag

### DIFF
--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -4,9 +4,9 @@ import argparse
 import os
 import re
 from functools import partial
-from pkg_resources import get_distribution
 
 import yaml
+from pkg_resources import get_distribution
 
 from nameko.exceptions import CommandError, ConfigurationError
 

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import re
 from functools import partial
+from pkg_resources import get_distribution
 
 import yaml
 
@@ -60,6 +61,12 @@ IMPLICIT_ENV_VAR_MATCHER = re.compile(
 
 def setup_parser():
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-v',
+        '--version',
+        action='version',
+        version=get_distribution('nameko').version
+    )
     subparsers = parser.add_subparsers()
 
     for command in commands.commands:


### PR DESCRIPTION
This PR adds a `-v` and `--version` flag to the base `nameko` CLI.

```
$ nameko -v
2.12.0

$ nameko --version
2.12.0
```

Let me know if the version output should be changed (e.g. `nameko v2.12.0`) and/or if there should also be tests for this :).