### PR TITLE
CLI nameko shell survives unconfigured broker (but prints warning)

### DIFF
--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -84,7 +84,7 @@ def main(interface):
     banner = "Nameko Python %s shell on %s\nBroker: %s" % (
         sys.version,
         sys.platform,
-        config[AMQP_URI_CONFIG_KEY],
+        config.get(AMQP_URI_CONFIG_KEY, "undefined!!!"),
     )
 
     ctx = {}


### PR DESCRIPTION
Resolve issue #664 by surviving attempt to read unconfigured AQMP uri and by printing "Broker: undefined!!!" at shell banner.