### PR TITLE
Import ABC from collections.abc for Python 3 compatibility.

### DIFF
--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -115,7 +115,10 @@ def rabbit_manager(request):
 
 @pytest.yield_fixture(scope='session')
 def vhost_pipeline(request, rabbit_manager):
-    from collections import Iterable
+    try:
+        from collections.abc import Iterable
+    except ImportError:
+        from collections import Iterable
     from six.moves.urllib.parse import urlparse  # pylint: disable=E0401
     import random
     import socket


### PR DESCRIPTION
Fixes #684 