### PR TITLE
Add conifg.setup() to standalone rpc example

### DIFF
--- a/docs/examples/standalone_rpc.py
+++ b/docs/examples/standalone_rpc.py
@@ -1,8 +1,11 @@
+from nameko import config
 from nameko.standalone.rpc import ClusterRpcProxy
 
-config = {
+
+conf = {
     'AMQP_URI': AMQP_URI  # e.g. "pyamqp://guest:guest@localhost"
 }
+config.setup(conf)
 
-with ClusterRpcProxy(config) as cluster_rpc:
+with ClusterRpcProxy(conf) as cluster_rpc:
     cluster_rpc.service_x.remote_method("hellø")  # "hellø-x-y"


### PR DESCRIPTION
Adds `config.setup()` to the given example for a standalone RPC call, which should make the example actually operational.

I didn't find `config.setup()` documented anywhere else in my searches when I was trying to get this to work.