### PR TITLE
Fix dependencies (2.x)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     url='http://github.com/nameko/nameko',
     packages=find_packages(exclude=['test', 'test.*']),
     install_requires=[
+        "dnspython<2",
         "eventlet>=0.20.1",
         "kombu>=4.2.0,<5",
         "mock>=1.2",

--- a/test/standalone/test_rpc_proxy.py
+++ b/test/standalone/test_rpc_proxy.py
@@ -710,7 +710,11 @@ class TestStandaloneProxyDisconnections(object):
             return True
 
         # subsequent calls succeed (after reconnecting via retry policy)
-        with wait_for_call(Connection, 'connect', callback=enable_after_retry):
+        with wait_for_call(
+            Connection,
+            "_establish_connection",
+            callback=enable_after_retry
+        ):
             assert service_rpc.echo(2) == 2
 
 

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -996,8 +996,11 @@ class TestPublisherDisconnections(object):
             return True
 
         # call 2 succeeds (after reconnecting via retry policy)
-        with patch_wait(Connection, 'connect', callback=enable_after_retry):
-
+        with patch_wait(
+            Connection,
+            "_establish_connection",
+            callback=enable_after_retry
+        ):
             payload2 = "payload2"
             with entrypoint_waiter(consumer_container, 'recv'):
                 with entrypoint_hook(publisher_container, 'send') as send:

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -1299,7 +1299,11 @@ class TestProxyDisconnections(object):
             return True
 
         # call 2 succeeds (after reconnecting via retry policy)
-        with patch_wait(Connection, 'connect', callback=enable_after_retry):
+        with patch_wait(
+            Connection,
+            "_establish_connection",
+            callback=enable_after_retry
+        ):
             with entrypoint_hook(client_container, 'echo') as echo:
                 assert echo(2) == 2
 
@@ -1494,7 +1498,11 @@ class TestResponderDisconnections(object):
             return True
 
         # call 2 succeeds (after reconnecting via retry policy)
-        with patch_wait(Connection, 'connect', callback=enable_after_retry):
+        with patch_wait(
+            Connection,
+            "_establish_connection",
+            callback=enable_after_retry
+        ):
             assert service_rpc.echo(2) == 2
 
 


### PR DESCRIPTION
* Pin `dnspython<2` - resolves #688
* Fix connection retry tests relying on changed kombu internals