### PR TITLE
Travis badge should point to master only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Nameko
 ======
 
-.. image:: https://secure.travis-ci.org/nameko/nameko.svg?branch=master
-   :target: http://travis-ci.org/nameko/nameko
+.. image:: https://secure.travis-ci.org/nameko/nameko/tree/master.svg
+   :target: http://travis-ci.org/nameko/nameko/tree/master
 
 *[nah-meh-koh]*
 


### PR DESCRIPTION
Currently it points to any latest build including open PRs.