### PR TITLE
docs: fix simple typo, speparate -> separate

### DIFF
--- a/test/test_container.py
+++ b/test/test_container.py
@@ -218,7 +218,7 @@ def test_container_doesnt_exhaust_max_workers(container):
     # start the first worker, which should wait for spam_continue
     container.spawn_worker(dep, ['ham'], {})
 
-    # start the next worker in a speparate thread,
+    # start the next worker in a separate thread,
     # because it should block until the first one completed
     gt = spawn(container.spawn_worker, dep, ['eggs'], {})
 


### PR DESCRIPTION
There is a small typo in test/test_container.py.

Should read `separate` rather than `speparate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md