### PR TITLE
Improve standalone RPC more reliable and fix nameko shell loading

### DIFF
--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -6,30 +6,28 @@ import yaml
 
 import nameko.cli.code as code
 from nameko.constants import AMQP_URI_CONFIG_KEY
-from nameko.standalone.events import event_dispatcher
-from nameko.standalone.rpc import ClusterRpcProxy
 
 from .commands import Shell
 
 
 class ShellRunner(object):
 
-    def __init__(self, banner, local):
+    def __init__(self, banner, get_local):
         self.banner = banner
-        self.local = local
+        self.local = get_local
 
     def bpython(self):
         import bpython  # pylint: disable=E0401
-        bpython.embed(banner=self.banner, locals_=self.local)
+        bpython.embed(banner=self.banner, locals_=self.local())
 
     def ipython(self):
         from IPython import embed  # pylint: disable=E0401
-        embed(banner1=self.banner, user_ns=self.local)
+        embed(banner1=self.banner, user_ns=self.local())
 
     def plain(self):
         code.interact(
             banner=self.banner,
-            local=self.local,
+            local=self.local(),
             raise_expections=not sys.stdin.isatty()
         )
 
@@ -44,7 +42,7 @@ class ShellRunner(object):
         startup = os.environ.get('PYTHONSTARTUP')
         if startup and os.path.isfile(startup):
             with open(startup, 'r') as f:
-                eval(compile(f.read(), startup, 'exec'), self.local)
+                eval(compile(f.read(), startup, 'exec'), self.local())
             del os.environ['PYTHONSTARTUP']
 
         for name in available_shells:
@@ -69,8 +67,10 @@ Usage:
 
     >>> n.dispatch_event('service', 'event_type', 'event_data')
 """
+    from nameko.standalone.rpc import ClusterRpcProxy
     proxy = ClusterRpcProxy(config)
     module.rpc = proxy.start()
+    from nameko.standalone.events import event_dispatcher
     module.dispatch_event = event_dispatcher(config)
     module.config = config
     module.disconnect = proxy.stop
@@ -78,7 +78,7 @@ Usage:
 
 
 def main(args):
-
+    sys.path.append('.')  # Add current working directory to System path
     if args.config:
         with open(args.config) as fle:
             config = yaml.unsafe_load(fle)
@@ -94,8 +94,7 @@ def main(args):
         broker_from
     )
 
-    ctx = {}
-    ctx['n'] = make_nameko_helper(config)
-
-    runner = ShellRunner(banner, ctx)
+    # ctx will be initialized via this lambda func after shell runner start
+    ctx_func = lambda: {'n': make_nameko_helper(config)}
+    runner = ShellRunner(banner, ctx_func)
     runner.start_shell(name=args.interface)

--- a/nameko/standalone/events.py
+++ b/nameko/standalone/events.py
@@ -12,7 +12,8 @@ def get_event_exchange(service_name):
     """
     exchange_name = "{}.events".format(service_name)
     exchange = Exchange(
-        exchange_name, type='topic', durable=True, delivery_mode=PERSISTENT
+        exchange_name, type='topic', durable=True, delivery_mode=PERSISTENT,
+        auto_delete=True,  # undeprecated https://github.com/celery/py-amqp/issues/286
     )
 
     return exchange

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -2,21 +2,22 @@ from __future__ import absolute_import
 
 import logging
 import socket
+import time
 
 from amqp.exceptions import ConnectionError
 from kombu import Connection
 from kombu.common import maybe_declare
 from kombu.messaging import Consumer
-
 from nameko import serialization
-from nameko.constants import AMQP_SSL_CONFIG_KEY, AMQP_URI_CONFIG_KEY
+from nameko.constants import AMQP_SSL_CONFIG_KEY, AMQP_URI_CONFIG_KEY, HEARTBEAT_CONFIG_KEY
 from nameko.containers import WorkerContext
-from nameko.exceptions import RpcTimeout
+from nameko.exceptions import RpcTimeout, ConfigurationError
 from nameko.extensions import Entrypoint
 from nameko.rpc import ReplyListener, ServiceProxy
 
-
 _logger = logging.getLogger(__name__)
+
+EXPECTED_IOERR_MSG_SET = {"Server unexpectedly closed connection"}
 
 
 class ConsumeEvent(object):
@@ -52,7 +53,8 @@ class ConsumeEvent(object):
             raise RuntimeError(
                 "This consumer has been stopped, and can no longer be used"
             )
-        if self.queue_consumer.connection.connected is False:
+        if self.queue_consumer.connection is None or \
+                self.queue_consumer.connection.connected is False:
             # we can't just reconnect here. the consumer (and its exclusive,
             # auto-delete reply queue) must be re-established _before_ sending
             # any request, otherwise the reply queue may not exist when the
@@ -80,6 +82,7 @@ class PollingQueueConsumer(object):
     the same correlation ID of the RPC-proxy call arrives.
     """
     consumer = None
+    connection = None
 
     def __init__(self, timeout=None):
         self.stopped = True
@@ -109,15 +112,31 @@ class PollingQueueConsumer(object):
         consumer.consume()
         self.consumer = consumer
 
+    def _setup_connection(self):
+        if self.connection is not None:
+            try:
+                self.connection.close()
+            except (socket.error, IOError):  # pragma: no cover
+                # If the socket has been closed, an IOError is raised, ignore
+                # it and assume the connection is already closed.
+                pass
+
+        amqp_uri = self.provider.container.config[AMQP_URI_CONFIG_KEY]
+        ssl = self.provider.container.config.get(AMQP_SSL_CONFIG_KEY)
+        self.heartbeat = self.provider.container.config.get(
+            HEARTBEAT_CONFIG_KEY, None  # default to not enable heartbeat
+        )
+        if self.heartbeat is not None and self.heartbeat < 0:
+            raise ConfigurationError("value for '%s' can not be negative" % HEARTBEAT_CONFIG_KEY)
+        self.connection = Connection(amqp_uri, ssl=ssl, heartbeat=self.heartbeat)
+
     def register_provider(self, provider):
         self.provider = provider
 
         self.serializer, self.accept = serialization.setup(
             provider.container.config)
 
-        amqp_uri = provider.container.config[AMQP_URI_CONFIG_KEY]
-        ssl = provider.container.config.get(AMQP_SSL_CONFIG_KEY)
-        self.connection = Connection(amqp_uri, ssl=ssl)
+        self._setup_connection()
 
         self.queue = provider.queue
         self._setup_consumer()
@@ -127,51 +146,127 @@ class PollingQueueConsumer(object):
         self.connection.close()
         self.stopped = True
 
-    def ack_message(self, msg):
-        msg.ack()
+    def ack_message(self, message):
+        # only attempt to ack if the message connection is alive;
+        # otherwise the message will already have been reclaimed by the broker
+        if message.channel.connection:
+            try:
+                message.ack()
+            except ConnectionError:  # pragma: no cover
+                pass  # ignore connection closing inside conditional
 
     def on_message(self, body, message):
         msg_correlation_id = message.properties.get('correlation_id')
+        unknown = False
         if msg_correlation_id not in self.provider._reply_events:
             _logger.debug(
                 "Unknown correlation id: %s", msg_correlation_id)
-
+            unknown = True
         self.replies[msg_correlation_id] = (body, message)
+        # ACK message here to notify broker that message has been received
+        # only if the msg is known by the consumer
+        if not unknown:
+            self.ack_message(message)
+
 
     def get_message(self, correlation_id):
+        start_time = time.time()
+        stop_waiting = False
+        # retrieve agreed heartbeat interval of both party by query the server
+        HEARTBEAT_INTERVAL = self.consumer.connection.get_heartbeat_interval()
+        RATE = lambda: min(2 + abs(time.time() - start_time) * .75 / HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL / 3)
+        true_timeout = lambda: abs(start_time + self.timeout - time.time()) if self.timeout is not None else None
+        remaining_timeout = lambda: (
+            min(abs(start_time + self.timeout - time.time()), HEARTBEAT_INTERVAL / RATE())
+            if self.timeout is not None else HEARTBEAT_INTERVAL / RATE()) if self.heartbeat else true_timeout()
+        is_timed_out = lambda: abs(time.time() - start_time) > self.timeout if self.timeout is not None else False
+        timed_out_err_msg = "Timeout after: {}".format(self.timeout)
 
-        try:
-            while correlation_id not in self.replies:
-                self.consumer.connection.drain_events(
-                    timeout=self.timeout
-                )
-
+        while correlation_id not in self.replies:
+            recover_connection = False
+            try:
+                if self.heartbeat:
+                    try:
+                        self.consumer.connection.heartbeat_check()
+                    except (ConnectionError, socket.error, IOError) as exc:
+                        _logger.info("Heart beat failed. System will auto recover broken connection, %s: %s",
+                                     type(exc).__name__, exc.args[0])
+                        raise
+                    else:
+                        _logger.debug("Heart beat OK")
+                self.consumer.connection.drain_events(timeout=remaining_timeout())
+            except socket.timeout:
+                # if socket timeout happen here, send a hearbeat and keep looping
+                # until self.timeout is reached or correlation_id is found
+                pass
+            except (ConnectionError, socket.error, IOError) as exc:
+                # in case this was a temporary error, attempt to reconnect
+                # and try again. if we fail to reconnect, the error will bubble
+                # wait till connection stable before retry
+                if isinstance(exc, IOError) and not isinstance(exc, socket.error):
+                    # check only certain IOError will attemt to reconnect otherwhile reraise
+                    if exc.args[0] not in EXPECTED_IOERR_MSG_SET:  # check error.message
+                        raise
+                if not is_timed_out():
+                    try:  # try to recover connection if there is still time
+                        recover_connection = True
+                        _logger.debug(
+                            "Stabilizing connection to message broker due to error, {}: {}".format(type(exc).__name__,
+                                                                                                   exc.args[0]))
+                        self._setup_connection()
+                        self.connection.ensure_connection(max_retries=2, timeout=true_timeout())
+                        if self.connection.connected is True:
+                            self._setup_consumer()
+                            recover_connection = False
+                            # continue the loop to start send a heartbeat and wait result with this new connection
+                        else:
+                            err_msg = "Unable to stabilizing connnection after error, {}: {}".format(type(exc).__name__,
+                                                                                                     exc.args[0])
+                            _logger.debug(err_msg)
+                            event = self.provider._reply_events.pop(correlation_id)
+                            event.send_exception(ConnectionError(err_msg))
+                            stop_waiting = True
+                    except socket.timeout:
+                        timed_out_err_msg = "Timeout after stabilizing connnection: {}".format(self.timeout)
+                        # continue the loop to try to recover connection until
+                        # either self.timeout is reached or correlation_id is found
+                    except (ConnectionError, socket.error) as exc2:
+                        err_msg = "Error during stabilizing connnection, {}: {}".format(type(exc2).__name__,
+                                                                                        exc2.args[0])
+                        _logger.debug(err_msg)
+                        event = self.provider._reply_events.pop(correlation_id)
+                        event.send_exception(ConnectionError(err_msg))
+                        recover_connection = True
+                        stop_waiting = True
+            except KeyboardInterrupt as exc:
+                event = self.provider._reply_events.pop(correlation_id)
+                event.send_exception(exc)
+                recover_connection = True
+                stop_waiting = True
+            finally:
+                if correlation_id in self.replies:
+                    body, message = self.replies.pop(correlation_id)
+                    self.provider.handle_message(body, message)
+                    stop_waiting = True
+                else:
+                    if is_timed_out() is True:
+                        _logger.debug(timed_out_err_msg)
+                        timeout_error = RpcTimeout(timed_out_err_msg)
+                        event = self.provider._reply_events.pop(correlation_id)
+                        event.send_exception(timeout_error)
+                        stop_waiting = True
+                if recover_connection:  # alway try to recover the connection before exit if this flag is True
+                    try:
+                        if self.connection.connected is False:
+                            self._setup_connection()
+                        self._setup_consumer()
+                    except socket.error as exc:
+                        _logger.debug("Socket error during setup consumer, %s: %s", type(exc).__name__, exc.args[0])
+                if stop_waiting:  # stop waiting for result, break the loop
+                    break
+        else:  # other thread may have receive the message coresponding to this correlation_id before enter wait loop
             body, message = self.replies.pop(correlation_id)
             self.provider.handle_message(body, message)
-
-        except socket.timeout:
-            # TODO: this conflates an rpc timeout with a socket read timeout.
-            # a better rpc proxy implementation would recover from a socket
-            # timeout if the rpc timeout had not yet been reached
-            timeout_error = RpcTimeout(self.timeout)
-            event = self.provider._reply_events.pop(correlation_id)
-            event.send_exception(timeout_error)
-
-            # timeout is implemented using socket timeout, so when it
-            # fires the connection is closed and must be re-established
-            self._setup_consumer()
-
-        except (IOError, ConnectionError) as exc:
-            # in case this was a temporary error, attempt to reconnect
-            # and try again. if we fail to reconnect, the error will bubble
-            self._setup_consumer()
-            self.get_message(correlation_id)
-
-        except KeyboardInterrupt as exc:
-            event = self.provider._reply_events.pop(correlation_id)
-            event.send_exception(exc)
-            # exception may have killed the connection
-            self._setup_consumer()
 
 
 class SingleThreadedReplyListener(ReplyListener):
@@ -187,6 +282,16 @@ class SingleThreadedReplyListener(ReplyListener):
         reply_event = ConsumeEvent(self.queue_consumer, correlation_id)
         self._reply_events[correlation_id] = reply_event
         return reply_event
+
+    def handle_message(self, body, message):
+        # attempt to ACK message if it hasn't been acked
+        if not message.acknowledged:
+            self.queue_consumer.ack_message(message)
+
+        correlation_id = message.properties.get('correlation_id')
+        # correlation_id must exist in _reply_events by the time this method is called
+        client_event = self._reply_events[correlation_id]
+        client_event.send(body)
 
 
 class StandaloneProxyBase(object):


### PR DESCRIPTION
Allow me to introduce my self, i am leader developer of a start up company which recently got acquired in Singapore. The core micro services internal RPC system of the product we developed was built using this nameko framework. In the past 3 years i've put a few changes to the framework to fix a couple of reliability issue (most are network issue). The main changes are the **Changes 1** mentioned below, which is to fix many weird network issues we were encountering on Production environment (RabbitMQ 3.6.x). Unfortunately there is no easy way to write a test-case for all these network issue so this PR may have to relied on the people review, comment and trust. Hope the owner of `nameko` framework can take a look in this PR and give some comment for all the changes implemented here.

**p/s**: I'm also the active maintainer/owner of these libraries: 
+[django-nameko](https://github.com/and3rson/django-nameko) : RPC connection pool implementation to use in conjunction with Nameko standalone RPC Proxy in any multi-threaded based non-nameko services such as: Django View, Django-Restframework API, Flask, ..)
+[nameko-django](https://github.com/tranvietanh1991/nameko-django) : A custom kombu serializer which does auto convert Django ORM/Queryset/DateTime/Date/Decimal using msgpack which can be configure to used in nameko services


### Changes 1: Improve standalone RPC to be more reliable
+ Add support for heartbeat in standalone RPC
+ Auto recover connection and retry if encounter network failure (only issue which know to be recoverable)
+ Change the behavior of PollingQueueConsumer to ack message on received instead of when result() method is called (this is to match the behavior of non-standalone rpc QueueConsumer)
### Changes 2: Fix nameko shell to load correctly
+ Fix nameko shell to properly import and init ClusterRpcProxy after PYTHONSTARTUP script loaded and ShellRunner started
+ Add current working directory to System path when start nameko shell (This is to solved auto import feature of other framework such as: Django ORM)
### Changes 3: Fix compatible issue with system was running older version of nameko (prior to 2.12)
+ Add back `auto_delete=True` option when init Exchange for events to fix compatible with system was running older version of nameko. Also this feature is not deprecated from AMQP 0-9-1 anymore (see: https://github.com/celery/py-amqp/issues/286)