### PR TITLE
fix ReplyListener on standalone rpc with custom publisher_options

### DIFF
--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -209,7 +209,7 @@ class ClusterRpcClient(object):
             'ssl', config.get(AMQP_SSL_CONFIG_KEY)
         )
 
-        self.reply_listener = ReplyListener(queue, timeout=timeout)
+        self.reply_listener = ReplyListener(queue, timeout=timeout, uri=self.amqp_uri, ssl=self.ssl)
 
         serialization_config = serialization.setup()
         self.serializer = publisher_options.pop(

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(here, 'README.rst'), 'r', 'utf-8') as handle:
 
 setup(
     name='nameko',
-    version='v3.0.0-rc9',
+    version='v3.0.0-rc10',
     description='A microservices framework for Python that lets service '
                 'developers concentrate on application logic and encourages '
                 'testability.',


### PR DESCRIPTION
The standalone rpc ReplyListener does not inherit any `amqp_uri` or `ssl` options passed to the constructor of its owning client.