### PR TITLE
Safe yaml

### DIFF
--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -16,6 +16,7 @@ from . import commands
 try:
     import regex
 except ImportError:  # pragma: no cover
+    has_regex_module = False
     ENV_VAR_MATCHER = re.compile(
         r"""
             \$\{       # match characters `${` literally
@@ -26,6 +27,7 @@ except ImportError:  # pragma: no cover
         """, re.VERBOSE
     )
 else:  # pragma: no cover
+    has_regex_module = True
     ENV_VAR_MATCHER = regex.compile(
         r"""
         \$\{                #  match ${
@@ -56,6 +58,18 @@ IMPLICIT_ENV_VAR_MATCHER = re.compile(
                     # between `${` and `}` literally
         .*          # matches any number of any characters
     """, re.VERBOSE
+)
+
+
+RECURSIVE_ENV_VAR_MATCHER = re.compile(
+    r"""
+        \$\{       # match characters `${` literally
+        ([^}]+)?   # matches any character except `}`
+        \}         # match character `}` literally
+        ([^$}]+)?  # matches any character except `}` or `$`
+        \}         # match character `}` literally
+    """,
+    re.VERBOSE,
 )
 
 
@@ -95,6 +109,14 @@ def _replace_env_var(match):
 
 def env_var_constructor(loader, node, raw=False):
     raw_value = loader.construct_scalar(node)
+
+    # detect and error on recursive environment variables
+    if not has_regex_module and RECURSIVE_ENV_VAR_MATCHER.match(
+        raw_value
+    ):  # pragma: no cover
+        raise ConfigurationError(
+            "Nested environment variable lookup requires the `regex` module"
+        )
     value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
     if value == raw_value:
         return value  # avoid recursion

--- a/nameko/cli/main.py
+++ b/nameko/cli/main.py
@@ -96,18 +96,20 @@ def _replace_env_var(match):
 def env_var_constructor(loader, node, raw=False):
     raw_value = loader.construct_scalar(node)
     value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
+    if value == raw_value:
+        return value  # avoid recursion
     return value if raw else yaml.safe_load(value)
 
 
 def setup_yaml_parser():
-    yaml.add_constructor('!env_var', env_var_constructor, yaml.UnsafeLoader)
+    yaml.add_constructor('!env_var', env_var_constructor, yaml.SafeLoader)
     yaml.add_constructor(
         '!raw_env_var',
         partial(env_var_constructor, raw=True),
-        yaml.UnsafeLoader
+        yaml.SafeLoader
     )
     yaml.add_implicit_resolver(
-        '!env_var', IMPLICIT_ENV_VAR_MATCHER, Loader=yaml.UnsafeLoader
+        '!env_var', IMPLICIT_ENV_VAR_MATCHER, Loader=yaml.SafeLoader
     )
 
 

--- a/nameko/cli/run.py
+++ b/nameko/cli/run.py
@@ -164,7 +164,7 @@ def main(args):
 
     if args.config:
         with open(args.config) as fle:
-            config = yaml.unsafe_load(fle)
+            config = yaml.safe_load(fle)
     else:
         config = {
             AMQP_URI_CONFIG_KEY: args.broker

--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -81,7 +81,7 @@ def main(args):
 
     if args.config:
         with open(args.config) as fle:
-            config = yaml.unsafe_load(fle)
+            config = yaml.safe_load(fle)
         broker_from = " (from --config)"
     else:
         config = {AMQP_URI_CONFIG_KEY: args.broker}

--- a/nameko/cli/show_config.py
+++ b/nameko/cli/show_config.py
@@ -6,6 +6,6 @@ import yaml
 def main(args):
 
     with open(args.config) as fle:
-        config = yaml.unsafe_load(fle)
+        config = yaml.safe_load(fle)
 
     print(yaml.dump(config, default_flow_style=False))

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -13,7 +13,7 @@ def parse_config_option(text):
     import yaml
     if '=' in text:
         key, value = text.strip().split('=', 1)
-        return key, yaml.unsafe_load(value)
+        return key, yaml.safe_load(value)
     else:
         return text, True
 

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -314,7 +314,7 @@ class TestConfigEnvironmentVariables(object):
             for key, val in env_vars.items():
                 os.environ[key] = val
 
-            results = yaml.unsafe_load(yaml_config)
+            results = yaml.safe_load(yaml_config)
             assert results == expected_config
 
     def test_cannot_recurse(self):
@@ -332,7 +332,7 @@ class TestConfigEnvironmentVariables(object):
         with patch.dict('os.environ'):
             os.environ["VAR1"] = "${VAR1}"
 
-            results = yaml.unsafe_load(yaml_config)
+            results = yaml.safe_load(yaml_config)
             assert results == {'FOO': "${VAR1}", 'BAR': [1, 2, 3]}
 
     @pytest.mark.parametrize(('yaml_config', 'env_vars', 'expected_config'), [
@@ -389,7 +389,7 @@ class TestConfigEnvironmentVariables(object):
             for key, val in env_vars.items():
                 os.environ[key] = val
 
-            results = yaml.unsafe_load(yaml_config)
+            results = yaml.safe_load(yaml_config)
             assert results == expected_config
 
     @pytest.mark.parametrize(('yaml_config', 'env_vars', 'expected_config'), [
@@ -429,5 +429,5 @@ class TestConfigEnvironmentVariables(object):
         with patch.dict('os.environ'):
             for key, val in env_vars.items():
                 os.environ[key] = val
-            results = yaml.unsafe_load(yaml_config)
+            results = yaml.safe_load(yaml_config)
             assert results == expected_config

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -406,7 +406,7 @@ class TestConfigEnvironmentVariables(object):
     )
     def test_detect_nested_env_vars(
         self, yaml_config, should_match
-    ):
+    ):  # pragma: no cover
         setup_yaml_parser()
 
         if should_match:

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -401,7 +401,10 @@ class TestConfigEnvironmentVariables(object):
             ),
         ],
     )
-    def test_detect_recursion(
+    @pytest.mark.skipif(
+        has_regex_module, reason="nested env vars are supported if regex installed"
+    )
+    def test_detect_nested_env_vars(
         self, yaml_config, should_match
     ):
         setup_yaml_parser()
@@ -469,4 +472,4 @@ class TestConfigEnvironmentVariables(object):
             else:  # pragma: no cover
                 with pytest.raises(ConfigurationError) as exc:
                     yaml.safe_load(yaml_config)
-                assert "Recursive environment variable lookup" in str(exc.value)
+                assert "Nested environment variable lookup" in str(exc.value)

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -310,10 +310,7 @@ class TestConfigEnvironmentVariables(object):
     ):
         setup_yaml_parser()
 
-        with patch.dict('os.environ'):
-            for key, val in env_vars.items():
-                os.environ[key] = val
-
+        with patch.dict(os.environ, env_vars):
             results = yaml.safe_load(yaml_config)
             assert results == expected_config
 
@@ -329,9 +326,7 @@ class TestConfigEnvironmentVariables(object):
                 - 3
         """
 
-        with patch.dict('os.environ'):
-            os.environ["VAR1"] = "${VAR1}"
-
+        with patch.dict(os.environ, {"VAR1": "${VAR1}"}):
             results = yaml.safe_load(yaml_config)
             assert results == {'FOO': "${VAR1}", 'BAR': [1, 2, 3]}
 
@@ -385,10 +380,7 @@ class TestConfigEnvironmentVariables(object):
     ):  # pragma: no cover
         setup_yaml_parser()
 
-        with patch.dict('os.environ'):
-            for key, val in env_vars.items():
-                os.environ[key] = val
-
+        with patch.dict(os.environ, env_vars):
             results = yaml.safe_load(yaml_config)
             assert results == expected_config
 
@@ -426,8 +418,6 @@ class TestConfigEnvironmentVariables(object):
     ):  # pragma: no cover
         setup_yaml_parser()
 
-        with patch.dict('os.environ'):
-            for key, val in env_vars.items():
-                os.environ[key] = val
+        with patch.dict(os.environ, env_vars):
             results = yaml.safe_load(yaml_config)
             assert results == expected_config

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -72,7 +72,6 @@ class TestOptions(object):
             ('number', 1),
             ('list', '[1, 2, 3]'),
             ('map', '{"foo": "bar"}'),
-            ('lookup', '!!python/name:ssl.CERT_REQUIRED'),
         )
 
         testdir.makepyfile(
@@ -93,7 +92,6 @@ class TestOptions(object):
                     ('number', 1),
                     ('list', [1, 2, 3]),
                     ('map', {'foo': 'bar'}),
-                    ('lookup', ssl.CERT_REQUIRED),
                     ('keyonly', True),
                 ]
 
@@ -106,7 +104,6 @@ class TestOptions(object):
                     'number': 1,
                     'list': [1, 2, 3],
                     'map': {'foo': 'bar'},
-                    'lookup': ssl.CERT_REQUIRED,
                     'keyonly': True,
                 }
                 assert rabbit_ssl_config['AMQP_SSL'] == expected_ssl_options


### PR DESCRIPTION
Updates the logic parsing environment variables in configuration files. Now uses the safe version of pyyaml's parser rather than the unsafe version.

Behaviour is unchanged except for the unsupported case of using nested environment variables without the optional `regex` package. Previously, depending on the structure of the string, a nested environment variable would _sometimes_ be parsed correctly and sometimes incorrectly. Now, if your config file contains a nested environment variable and you do not have the optional `regex` package installed, a `ConfigurationError` will be raised.