### PR TITLE
Safe yaml v3

### DIFF
--- a/nameko/cli/utils/config.py
+++ b/nameko/cli/utils/config.py
@@ -91,22 +91,24 @@ def _replace_env_var(match):
 def env_var_constructor(loader, node, raw=False):
     raw_value = loader.construct_scalar(node)
     value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
+    if value == raw_value:
+        return value  # avoid recursion
     return value if raw else yaml.safe_load(value)
 
 
 def setup_yaml_parser():
-    yaml.add_constructor("!env_var", env_var_constructor, yaml.UnsafeLoader)
+    yaml.add_constructor("!env_var", env_var_constructor, yaml.SafeLoader)
     yaml.add_constructor(
-        "!raw_env_var", partial(env_var_constructor, raw=True), yaml.UnsafeLoader
+        "!raw_env_var", partial(env_var_constructor, raw=True), yaml.SafeLoader
     )
     yaml.add_implicit_resolver(
-        "!env_var", IMPLICIT_ENV_VAR_MATCHER, Loader=yaml.UnsafeLoader
+        "!env_var", IMPLICIT_ENV_VAR_MATCHER, Loader=yaml.SafeLoader
     )
 
 
 def load_config(config_file):
     setup_yaml_parser()
-    return yaml.unsafe_load(config_file)
+    return yaml.safe_load(config_file)
 
 
 def setup_config(config_file, define=None, broker=None):

--- a/nameko/cli/utils/config.py
+++ b/nameko/cli/utils/config.py
@@ -110,7 +110,7 @@ def env_var_constructor(loader, node, raw=False):
         raw_value
     ):  # pragma: no cover
         raise ConfigurationError(
-            "Recursive environment variable lookup requires the `regex` module"
+            "Nested environment variable lookup requires the `regex` module"
         )
     value = ENV_VAR_MATCHER.sub(_replace_env_var, raw_value)
     if value == raw_value:

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -16,7 +16,7 @@ def parse_config_option(text):
     import yaml
     if '=' in text:
         key, value = text.strip().split('=', 1)
-        return key, yaml.unsafe_load(value)
+        return key, yaml.safe_load(value)
     else:
         return text, True
 

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -343,7 +343,7 @@ class TestConfigEnvironmentVariables(object):
             for key, val in env_vars.items():
                 os.environ[key] = val
 
-            results = yaml.unsafe_load(yaml_config)
+            results = yaml.safe_load(yaml_config)
             assert results == expected_config
 
     def test_cannot_recurse(self):
@@ -361,7 +361,7 @@ class TestConfigEnvironmentVariables(object):
         with patch.dict("os.environ"):
             os.environ["VAR1"] = "${VAR1}"
 
-            results = yaml.unsafe_load(yaml_config)
+            results = yaml.safe_load(yaml_config)
             assert results == {"FOO": "${VAR1}", "BAR": [1, 2, 3]}
 
     @pytest.mark.parametrize(
@@ -421,7 +421,7 @@ class TestConfigEnvironmentVariables(object):
             for key, val in env_vars.items():
                 os.environ[key] = val
 
-            results = yaml.unsafe_load(yaml_config)
+            results = yaml.safe_load(yaml_config)
             assert results == expected_config
 
     @pytest.mark.parametrize(
@@ -462,5 +462,5 @@ class TestConfigEnvironmentVariables(object):
         with patch.dict("os.environ"):
             for key, val in env_vars.items():
                 os.environ[key] = val
-            results = yaml.unsafe_load(yaml_config)
+            results = yaml.safe_load(yaml_config)
             assert results == expected_config

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -339,10 +339,7 @@ class TestConfigEnvironmentVariables(object):
     def test_environment_vars_in_config(self, yaml_config, env_vars, expected_config):
         setup_yaml_parser()
 
-        with patch.dict("os.environ"):
-            for key, val in env_vars.items():
-                os.environ[key] = val
-
+        with patch.dict(os.environ, env_vars):
             results = yaml.safe_load(yaml_config)
             assert results == expected_config
 
@@ -358,9 +355,7 @@ class TestConfigEnvironmentVariables(object):
                 - 3
         """
 
-        with patch.dict("os.environ"):
-            os.environ["VAR1"] = "${VAR1}"
-
+        with patch.dict(os.environ, {"VAR1": "${VAR1}"}):
             results = yaml.safe_load(yaml_config)
             assert results == {"FOO": "${VAR1}", "BAR": [1, 2, 3]}
 
@@ -417,10 +412,7 @@ class TestConfigEnvironmentVariables(object):
     ):  # pragma: no cover
         setup_yaml_parser()
 
-        with patch.dict("os.environ"):
-            for key, val in env_vars.items():
-                os.environ[key] = val
-
+        with patch.dict(os.environ, env_vars):
             results = yaml.safe_load(yaml_config)
             assert results == expected_config
 
@@ -459,8 +451,6 @@ class TestConfigEnvironmentVariables(object):
     ):  # pragma: no cover
         setup_yaml_parser()
 
-        with patch.dict("os.environ"):
-            for key, val in env_vars.items():
-                os.environ[key] = val
+        with patch.dict(os.environ, env_vars):
             results = yaml.safe_load(yaml_config)
             assert results == expected_config

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -431,7 +431,10 @@ class TestConfigEnvironmentVariables(object):
             ),
         ],
     )
-    def test_detect_recursion(
+    @pytest.mark.skipif(
+        has_regex_module, reason="nested env vars are supported if regex installed"
+    )
+    def test_detect_nested_env_vars(
         self, yaml_config, should_match
     ):
         setup_yaml_parser()
@@ -499,4 +502,4 @@ class TestConfigEnvironmentVariables(object):
             else:  # pragma: no cover
                 with pytest.raises(ConfigurationError) as exc:
                     yaml.safe_load(yaml_config)
-                assert "Recursive environment variable lookup" in str(exc.value)
+                assert "Nested environment variable lookup" in str(exc.value)

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -436,7 +436,7 @@ class TestConfigEnvironmentVariables(object):
     )
     def test_detect_nested_env_vars(
         self, yaml_config, should_match
-    ):
+    ):  # pragma: no cover
         setup_yaml_parser()
 
         if should_match:

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -145,6 +145,7 @@ class TestConfigEnvironmentParser(object):
 
 
 class TestConfigEnvironmentVariables(object):
+
     @pytest.mark.parametrize(
         ("yaml_config", "env_vars", "expected_config"),
         [
@@ -360,6 +361,88 @@ class TestConfigEnvironmentVariables(object):
             assert results == {"FOO": "${VAR1}", "BAR": [1, 2, 3]}
 
     @pytest.mark.parametrize(
+        ("yaml_config", "should_match"),
+        [
+            # no recursion
+            (
+                """
+                FOO: ${FOO:foo}
+                """,
+                False
+            ),
+            # no recursion, multiple entries
+            (
+                """
+                FOO: ${FOO:foo}-${BAR:bar}
+                """,
+                False
+            ),
+            # no recursion, multiple lines
+            (
+                """
+                FOO: ${FOO:foo}
+                BAR: ${BAR:bar}
+                """,
+                False
+            ),
+            # no recursion, multiple entries containing $
+            (
+                """
+                FOO: ${FOO:$123}-${BAR:bar}
+                """,
+                False
+            ),
+            # recursive with default
+            (
+                """
+                FOO: ${FOO:val_${INDICE:1}}
+                BAR: bar
+                """,
+                True
+            ),
+            # recursive with default containing $
+            (
+                """
+                FOO: ${FOO:val_${INDICE:$1}}
+                BAR: bar
+                """,
+                True
+            ),
+            # recursive without default
+            (
+                """
+                FOO: ${FOO:val_${INDICE}}
+                """,
+                True
+            ),
+            # recursive containing $
+            (
+                """
+                FOO: ${FOO:val_${IN$ICE}}
+                """,
+                True
+            ),
+            # default data with bracket
+            (
+                """
+                FOO: ${FOO:"{name} {age}"}
+                """,
+                True
+            ),
+        ],
+    )
+    def test_detect_recursion(
+        self, yaml_config, should_match
+    ):
+        setup_yaml_parser()
+
+        if should_match:
+            with pytest.raises(ConfigurationError):
+                yaml.safe_load(yaml_config)
+        else:
+            assert yaml.safe_load(yaml_config)
+
+    @pytest.mark.parametrize(
         ("yaml_config", "env_vars", "expected_config"),
         [
             # recursive env with root value
@@ -404,53 +487,16 @@ class TestConfigEnvironmentVariables(object):
             ),
         ],
     )
-    @pytest.mark.skipif(
-        not has_regex_module, reason="0 support for nested env without regex module"
-    )
     def test_environment_vars_recursive_in_config(
         self, yaml_config, env_vars, expected_config
-    ):  # pragma: no cover
+    ):
         setup_yaml_parser()
 
         with patch.dict(os.environ, env_vars):
-            results = yaml.safe_load(yaml_config)
-            assert results == expected_config
-
-    @pytest.mark.parametrize(
-        ("yaml_config", "env_vars", "expected_config"),
-        [
-            # recursive env with root value
-            (
-                """
-            FOO: ${FOO:val_${INDICE:1}}
-            """,
-                {"FOO": "val_a"},
-                {"FOO": "val_a}"},
-            ),
-            # recursive env with root default and sub value
-            (
-                """
-            FOO: ${FOO:val_${INDICE:1}}
-            """,
-                {"INDICE": "b"},
-                {"FOO": "val_${INDICE:1}"},
-            ),
-            # recursive env requiring data
-            (
-                """
-            FOO: ${FOO:${INDICE}_val}
-            """,
-                {"INDICE": "b"},
-                {"FOO": "${INDICE_val}"},
-            ),
-        ],
-    )
-    @pytest.mark.skipif(has_regex_module, reason="default behavior if no regex module")
-    def test_unhandled_recursion(
-        self, yaml_config, env_vars, expected_config
-    ):  # pragma: no cover
-        setup_yaml_parser()
-
-        with patch.dict(os.environ, env_vars):
-            results = yaml.safe_load(yaml_config)
-            assert results == expected_config
+            if has_regex_module:  # pragma: no cover
+                results = yaml.safe_load(yaml_config)
+                assert results == expected_config
+            else:  # pragma: no cover
+                with pytest.raises(ConfigurationError) as exc:
+                    yaml.safe_load(yaml_config)
+                assert "Recursive environment variable lookup" in str(exc.value)

--- a/test/testing/test_pytest_plugin.py
+++ b/test/testing/test_pytest_plugin.py
@@ -73,7 +73,6 @@ class TestOptions(object):
             ('number', 1),
             ('list', '[1, 2, 3]'),
             ('map', '{"foo": "bar"}'),
-            ('lookup', '!!python/name:ssl.CERT_REQUIRED'),
         )
 
         testdir.makepyfile(
@@ -99,7 +98,6 @@ class TestOptions(object):
                     ('number', 1),
                     ('list', [1, 2, 3]),
                     ('map', {'foo': 'bar'}),
-                    ('lookup', ssl.CERT_REQUIRED),
                     ('keyonly', True),
                 ]
 
@@ -112,7 +110,6 @@ class TestOptions(object):
                     'number': 1,
                     'list': [1, 2, 3],
                     'map': {'foo': 'bar'},
-                    'lookup': ssl.CERT_REQUIRED,
                     'keyonly': True,
                 }
                 assert config['AMQP_SSL'] == expected_ssl_options


### PR DESCRIPTION
Equivalent to #722, for v3 branch

--

Updates the logic parsing environment variables in configuration files. Now uses the safe version of pyyaml's parser rather than the unsafe version.

Behaviour is unchanged except for the unsupported case of using nested environment variables without the optional `regex` package. Previously, depending on the structure of the string, a nested environment variable would _sometimes_ be parsed correctly and sometimes incorrectly. Now, if your config file contains a nested environment variable and you do not have the optional `regex` package installed, a `ConfigurationError` will be raised.