### PR TITLE
fix websockets in werkzeug 2x

### DIFF
--- a/nameko/web/websocket.py
+++ b/nameko/web/websocket.py
@@ -3,13 +3,13 @@ import uuid
 from collections import namedtuple
 from functools import partial
 from logging import getLogger
-from packaging import version
 
 import six
+import werkzeug
 from eventlet.event import Event
 from eventlet.websocket import WebSocketWSGI
+from packaging import version
 from werkzeug.routing import Rule
-import werkzeug
 
 from nameko.exceptions import (
     ConnectionNotFound, MalformedRequest, MethodNotFound, serialize
@@ -18,6 +18,7 @@ from nameko.extensions import (
     DependencyProvider, Entrypoint, ProviderCollector, SharedExtension
 )
 from nameko.web.server import WebServer
+
 
 # in version 2.0.0, werkzeug started correctly identifying incoming websocket
 # requests, and only matching them to rules that are marked as being websocket targets.

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "six>=1.9.0",
         "werkzeug>=0.9",
         "wrapt>=1.0.0",
+        "packaging",
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "pyyaml>=5.1",
         "requests>=1.2.0",
         "six>=1.9.0",
-        "werkzeug>=0.9,<2",
+        "werkzeug>=0.9",
         "wrapt>=1.0.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "pyyaml>=5.1",
         "requests>=1.2.0",
         "six>=1.9.0",
-        "werkzeug>=0.9",
+        "werkzeug>=1.0.0",
         "wrapt>=1.0.0",
         "packaging",
     ],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "pyyaml>=5.1",
         "requests>=1.2.0",
         "six>=1.9.0",
-        "werkzeug>=0.9",
+        "werkzeug>=0.9,<2",
         "wrapt>=1.0.0",
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     oldest: path.py==6.2
     oldest: requests==2.4.3
     oldest: six==1.10.0
-    oldest: werkzeug==0.9
+    oldest: werkzeug==1.0.0
     oldest: wrapt==1.0.0
 
     # pinned library versions
@@ -22,7 +22,7 @@ deps =
     pinned: path.py==11.0.1
     pinned: requests==2.19.1
     pinned: six==1.11.0
-    pinned: werkzeug==0.14.1
+    pinned: werkzeug==2.0.1
     pinned: wrapt==1.10.11
 
     {py3.5,py3.6}-extra: regex==2018.07.11

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     pinned: path.py==11.0.1
     pinned: requests==2.19.1
     pinned: six==1.11.0
-    pinned: werkzeug==2.0.1
+    pinned: werkzeug==1.0.1
     pinned: wrapt==1.10.11
 
     {py3.5,py3.6}-extra: regex==2018.07.11


### PR DESCRIPTION
Beginning with 2.0.0, Werkzeug started identifying incoming websocket requests, and only matching them to rules that are marked as being websocket targets. See https://github.com/pallets/werkzeug/issues/2052.

This breaks Nameko's websocket functionality which defines some rules that were not marked as being websocket targets, which thus no longer match, resulting in a 400 error. With Werkzeug 2x it is sufficient to simply mark these rules as being websocket targets, but this results in a 400 error Werkzeug 1x for the same reason -- no rule matches the type of request framework determines the request to be.

This PR makes the explicit identification of a rule as a websocket target conditional on the version of Werkzeug. Furthermore, in Werkzeug < 1.0.0 the Rule constructor doesn't even accept the `websocket` argument, so this PR also drops support for those versions.

Alternatives to the approach taken here are:

- Not supporting Werkzeug 2x
- Only supporting Werkzeug 2x and dropping support for older versions
- Forcing the auto-detection of websocket requests off (by passing `websocket=False` into [`adapter.match()`](https://github.com/nameko/nameko/blob/b0862d7f390f4e58f6de847305ad07a48ce127ae/nameko/web/server.py#L176))

The conditional is the most explicit solution and is easily removed if we decide to drop support for Werkzeug 1.x in the future.
