### PR TITLE
Fixes for `nameko test` command

### DIFF
--- a/nameko/cli/commands.py
+++ b/nameko/cli/commands.py
@@ -160,7 +160,13 @@ class Test(Command):
 
         import pytest
         import sys
-        exit_code = pytest.main(list(unknown_args))
+
+        args = list(unknown_args)
+        args.extend(
+            ["-W", "ignore:Module already imported:_pytest.warning_types.PytestWarning"]
+        )
+
+        exit_code = pytest.main(args)
         sys.exit(exit_code.value)
 
 commands = Command.__subclasses__()  # pylint: disable=E1101

--- a/nameko/cli/commands.py
+++ b/nameko/cli/commands.py
@@ -159,7 +159,8 @@ class Test(Command):
         eventlet.monkey_patch()  # noqa (code before imports)
 
         import pytest
-        pytest.main(list(unknown_args))
-
+        import sys
+        exit_code = pytest.main(list(unknown_args))
+        sys.exit(exit_code.value)
 
 commands = Command.__subclasses__()  # pylint: disable=E1101

--- a/nameko/cli/commands.py
+++ b/nameko/cli/commands.py
@@ -169,4 +169,5 @@ class Test(Command):
         exit_code = pytest.main(args)
         sys.exit(exit_code.value)
 
+
 commands = Command.__subclasses__()  # pylint: disable=E1101

--- a/nameko/cli/commands.py
+++ b/nameko/cli/commands.py
@@ -167,7 +167,7 @@ class Test(Command):
         )
 
         exit_code = pytest.main(args)
-        sys.exit(exit_code.value)
+        sys.exit(int(exit_code))
 
 
 commands = Command.__subclasses__()  # pylint: disable=E1101

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -31,3 +31,20 @@ def test_test_fail(tmpdir, capsys):
     )
     proc.wait()
     assert proc.returncode == 1
+
+def test_suppress_warning(tmpdir, capsys):
+
+    tmpdir.join('__init__.py')
+    testfile = tmpdir.join('test_test_pass.py')
+    testfile.write(dedent("""
+        def test_foo():
+            assert True
+    """))
+
+    proc = subprocess.Popen(
+        ["nameko", "test", testfile.strpath], stdout=subprocess.PIPE
+    )
+    proc.wait()
+
+    out = "".join(map(bytes.decode, proc.stdout.readlines()))
+    assert "Module already imported so cannot be rewritten: nameko" not in out

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -36,7 +36,7 @@ def test_test_fail(tmpdir, capsys):
     assert proc.returncode == 1
 
 
-def test_suppress_warning(tmpdir, capsys):
+def test_suppress_warning(tmpdir, capsys):  # pragma: no cover
 
     if tuple(map(int, pytest.__version__.split("."))) < (6, 1):
         pytest.skip("-W flag ignored on older pytests")

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -1,5 +1,5 @@
-from textwrap import dedent
 import subprocess
+from textwrap import dedent
 
 
 def test_test_pass(tmpdir, capsys):
@@ -17,6 +17,7 @@ def test_test_pass(tmpdir, capsys):
     proc.wait()
     assert proc.returncode == 0
 
+
 def test_test_fail(tmpdir, capsys):
 
     tmpdir.join('__init__.py')
@@ -31,6 +32,7 @@ def test_test_fail(tmpdir, capsys):
     )
     proc.wait()
     assert proc.returncode == 1
+
 
 def test_suppress_warning(tmpdir, capsys):
 

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -36,6 +36,9 @@ def test_test_fail(tmpdir, capsys):
 
 def test_suppress_warning(tmpdir, capsys):
 
+    if tuple(map(int, pytest.__version__.split("."))) < (6,1):
+        pytest.skip("-W flag ignored on older pytests")
+
     tmpdir.join('__init__.py')
     testfile = tmpdir.join('test_test_pass.py')
     testfile.write(dedent("""

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -1,0 +1,33 @@
+from textwrap import dedent
+import subprocess
+
+
+def test_test_pass(tmpdir, capsys):
+
+    tmpdir.join('__init__.py')
+    testfile = tmpdir.join('test_test_pass.py')
+    testfile.write(dedent("""
+        def test_foo():
+            assert True
+    """))
+
+    proc = subprocess.Popen(
+        ["nameko", "test", testfile.strpath], stdout=subprocess.PIPE
+    )
+    proc.wait()
+    assert proc.returncode == 0
+
+def test_test_fail(tmpdir, capsys):
+
+    tmpdir.join('__init__.py')
+    testfile = tmpdir.join('test_test_fail.py')
+    testfile.write(dedent("""
+        def test_foo():
+            assert False
+    """))
+
+    proc = subprocess.Popen(
+        ["nameko", "test", testfile.strpath], stdout=subprocess.PIPE
+    )
+    proc.wait()
+    assert proc.returncode == 1

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -1,6 +1,8 @@
 import subprocess
 from textwrap import dedent
 
+import pytest
+
 
 def test_test_pass(tmpdir, capsys):
 
@@ -36,7 +38,7 @@ def test_test_fail(tmpdir, capsys):
 
 def test_suppress_warning(tmpdir, capsys):
 
-    if tuple(map(int, pytest.__version__.split("."))) < (6,1):
+    if tuple(map(int, pytest.__version__.split("."))) < (6, 1):
         pytest.skip("-W flag ignored on older pytests")
 
     tmpdir.join('__init__.py')


### PR DESCRIPTION
Two small fixes:

1. `nameko test` now exits with the return code of the underlying `pytest` command. This is important for use in CI, which usually relies on the return code to know whether tests pass.
2. `nameko test` now suppresses the module rewrite pytest warning. This warning is designed to alert users that running multiple pytest sessions in the same process can have negative consequences. We're not doing that here so the warning is safe to suppress.