### PR TITLE
REDACT secrets in error message for HA connection strings

### DIFF
--- a/nameko/amqp/consume.py
+++ b/nameko/amqp/consume.py
@@ -5,7 +5,7 @@ from amqp.exceptions import ConnectionError
 from kombu import Connection
 from kombu.mixins import ConsumerMixin
 
-from nameko.utils import sanitize_url
+from nameko.utils import sanitize_connection_string
 
 
 _log = getLogger(__name__)
@@ -89,7 +89,7 @@ class Consumer(ConsumerMixin):
         _log.warning(
             "Error connecting to broker at {} ({}).\n"
             "Retrying in {} seconds."
-            .format(sanitize_url(self.amqp_uri), exc, interval)
+            .format(sanitize_connection_string(self.amqp_uri), exc, interval)
         )
 
     def on_message(self, body, message):

--- a/nameko/utils/__init__.py
+++ b/nameko/utils/__init__.py
@@ -134,3 +134,14 @@ def sanitize_url(url):
     parts = parts._replace(netloc='{}:{}@{}'.format(
         parts.username, REDACTED, host_info))
     return parts.geturl()
+
+
+def sanitize_connection_string(s):
+    """Sanitize the connection string"""
+    if not isinstance(s, str):
+        # it could be a list or set of urls per kombu.connection.Connection
+        return [sanitize_url(_) for _ in s]
+    elif ';' in s:
+        return ';'.join([sanitize_url(_) for _ in s.split(';')])
+    else:
+        return sanitize_url(s)

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -10,7 +10,7 @@ from nameko.extensions import DependencyProvider
 from nameko.rpc import Rpc, rpc
 from nameko.testing.services import dummy, entrypoint_hook, get_extension
 from nameko.utils import (
-    REDACTED, get_redacted_args, import_from_path, sanitize_url
+    REDACTED, get_redacted_args, import_from_path, sanitize_url, connection_url
 )
 from nameko.utils.concurrency import fail_fast_imap
 
@@ -259,4 +259,31 @@ class TestImportFromPath(object):
 ])
 def test_sanitize_url(url, expected):
     actual = sanitize_url(url)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('connection_url,expected', [
+    (
+        'amqp://user:supersecret@127.0.0.1:5672//',
+        'amqp://user:{}@127.0.0.1:5672//'.format(REDACTED)
+    ),
+    (
+        'amqp://user@127.0.0.1:5672//',
+        'amqp://user@127.0.0.1:5672//'
+    ),
+    (
+        'amqp://127.0.0.1:5672//',
+        'amqp://127.0.0.1:5672//'
+    ),
+    (
+        'amqp://user:supersecret@127.0.0.1:5672//;amqp://user:supersecret@127.0.0.2:5672//',
+        'amqp://user:{}@127.0.0.1:5672//;amqp://user:{}@127.0.0.2:5672//'.format(REDACTED, REDACTED)
+    ),
+    (
+        ['amqp://user:supersecret@127.0.0.1:5672//', 'amqp://user:supersecret@127.0.0.2:5672//'],
+        ['amqp://user:{}@127.0.0.1:5672//'.format(REDACTED), 'amqp://user:{}@127.0.0.2:5672//'.format(REDACTED)]
+    ),
+])
+def test_sanitize_connection_url(connection_url, expected):
+    actual = sanitize_connection_url(connection_url)
     assert actual == expected


### PR DESCRIPTION
When using a multi host connection string "amqp://127.0.0.1;amqp://127.0.0.2", kombu.connection.Connection accepts either a ';' delimited list, or a Sequence (list, set...)
The nameko sanitize_url does not properly sanitize the multiple connection strings in these cases as it expects only a single url.