### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
         TOXENV: py${{ matrix.python-version }}-examples
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
@@ -82,6 +82,7 @@ jobs:
           - 3.9
           - 3.8
           - 3.7
+          - 3.6
           - 2.7
         dependency-set:
           - pinned

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,6 @@ jobs:
           - 3.9
           - 3.8
           - 3.7
-          - 3.6
           - 2.7
         dependency-set:
           - pinned
@@ -138,7 +137,7 @@ jobs:
         TOXENV: py${{ matrix.python-version }}-${{ matrix.dependency-set }}-${{ matrix.command }}
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,6 @@ jobs:
           - 3.9
           - 3.8
           - 3.7
-          - 3.6
           - 2.7
         dependency-set:
           - pinned

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
         TOXENV: py${{ matrix.python-version }}-examples
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ pylint:
 	pylint --rcfile=pylintrc nameko -E
 
 imports:
-	isort -rc $(autofix) nameko test
+	isort $(autofix) nameko test
 
 test_lib:
 	BRANCH=$(ENABLE_BRANCH_COVERAGE) coverage run -m nameko test test -v --strict --timeout 30

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ imports:
 	isort $(autofix) nameko test
 
 test_lib:
-	BRANCH=$(ENABLE_BRANCH_COVERAGE) coverage run -m nameko test test -v --strict --timeout 30
+	BRANCH=$(ENABLE_BRANCH_COVERAGE) coverage run -m nameko test test -v --strict-markers --timeout 30
 	BRANCH=$(ENABLE_BRANCH_COVERAGE) coverage report
 
 test_examples:
-	BRANCH=$(ENABLE_BRANCH_COVERAGE) nameko test docs/examples/test --strict --timeout 30 --cov=docs/examples --cov-config=$(CURDIR)/.coveragerc
+	BRANCH=$(ENABLE_BRANCH_COVERAGE) nameko test docs/examples/test --strict-markers --timeout 30 --cov=docs/examples --cov-config=$(CURDIR)/.coveragerc
 	nameko test docs/examples/testing
 
 test_docs: docs spelling #linkcheck

--- a/docs/examples/auth.py
+++ b/docs/examples/auth.py
@@ -33,7 +33,7 @@ class Auth(DependencyProvider):
                 'username': username,
                 'roles': self.users[username]['roles']
             }
-            token = jwt.encode(payload, key=JWT_SECRET).decode('utf-8')
+            token = jwt.encode(payload, key=JWT_SECRET, algorithm="HS256")
             self.worker_ctx.context_data['auth'] = token
             return token
 
@@ -43,7 +43,9 @@ class Auth(DependencyProvider):
                 raise Unauthenticated()
 
             try:
-                payload = jwt.decode(token, key=JWT_SECRET, verify=True)
+                payload = jwt.decode(
+                    token, key=JWT_SECRET, verify=True, algorithms=["HS256"]
+                )
                 if role in payload['roles']:
                     return True
             except Exception:

--- a/docs/examples/test/test_examples.py
+++ b/docs/examples/test/test_examples.py
@@ -368,7 +368,7 @@ class TestAuth:
         worker_ctx = Mock(context_data={})
         dep = Auth.Api(db, worker_ctx)
         token = dep.authenticate("matt", "secret")
-        jwt.decode(token, key=JWT_SECRET, verify=True)
+        jwt.decode(token, key=JWT_SECRET, verify=True, algorithms=["HS256"])
         assert worker_ctx.context_data['auth'] == token
 
     def test_authenticate_bad_username(self, db):
@@ -482,7 +482,7 @@ class TestSensitiveArguments:
 
         with ServiceRpcClient("service") as client:
             token = client.login("matt", "secret")
-            jwt.decode(token, key=JWT_SECRET, verify=True)
+            jwt.decode(token, key=JWT_SECRET, verify=True, algorithms=["HS256"])
             with pytest.raises(RemoteError) as exc:
                 client.login("matt", "incorrect")
             assert exc.value.exc_type == "Unauthenticated"

--- a/docs/examples/testing/alternative_dependency_unit_test.py
+++ b/docs/examples/testing/alternative_dependency_unit_test.py
@@ -3,8 +3,7 @@
 
 import pytest
 from sqlalchemy import Column, Integer, String, create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 from nameko.rpc import rpc
 from nameko.testing.services import worker_factory

--- a/nameko/cli/__init__.py
+++ b/nameko/cli/__init__.py
@@ -3,15 +3,12 @@ import click
 from nameko import config
 from nameko.exceptions import CommandError, ConfigurationError
 
-from .utils import setup_config
 from .click_arguments import argument_services
 from .click_options import (
-    option_broker,
-    option_config_file,
-    option_define,
-    option_backdoor_port,
-    option_interface,
+    option_backdoor_port, option_broker, option_config_file, option_define,
+    option_interface
 )
+from .utils import setup_config
 
 
 # main nameko command
@@ -93,8 +90,9 @@ def test(args):
     import eventlet
     eventlet.monkey_patch()  # noqa (code before rest of imports)
 
-    import pytest
     import sys
+
+    import pytest
 
     args = list(args)
     args.extend(

--- a/nameko/cli/utils/__init__.py
+++ b/nameko/cli/utils/__init__.py
@@ -1,5 +1,5 @@
 """Importing all relevant utility functions.
 """
-from .config import setup_config  # noqa
 from .code import interact  # noqa
+from .config import setup_config  # noqa
 from .import_services import import_services  # noqa

--- a/nameko/rpc.py
+++ b/nameko/rpc.py
@@ -17,8 +17,7 @@ from nameko.amqp.publish import Publisher, UndeliverableMessage, get_connection
 from nameko.constants import (
     AMQP_SSL_CONFIG_KEY, AMQP_URI_CONFIG_KEY, DEFAULT_AMQP_URI,
     DEFAULT_HEARTBEAT, DEFAULT_PREFETCH_COUNT, HEARTBEAT_CONFIG_KEY,
-    LOGIN_METHOD_CONFIG_KEY, PREFETCH_COUNT_CONFIG_KEY,
-    RPC_EXCHANGE_CONFIG_KEY
+    LOGIN_METHOD_CONFIG_KEY, PREFETCH_COUNT_CONFIG_KEY, RPC_EXCHANGE_CONFIG_KEY
 )
 from nameko.exceptions import (
     ContainerBeingKilled, MalformedRequest, MethodNotFound,

--- a/nameko/testing/pytest.py
+++ b/nameko/testing/pytest.py
@@ -125,7 +125,8 @@ def empty_config():
 @pytest.fixture
 def mock_container(request):
     from mock import create_autospec
-    from nameko.constants import SERIALIZER_CONFIG_KEY, DEFAULT_SERIALIZER
+
+    from nameko.constants import DEFAULT_SERIALIZER, SERIALIZER_CONFIG_KEY
     from nameko.containers import ServiceContainer
 
     container = create_autospec(ServiceContainer)
@@ -151,10 +152,12 @@ def vhost_pipeline(request, rabbit_manager):
     except ImportError:  # pragma: no cover
         # py2 compatibility
         from collections import Iterable  # pylint: disable=E0611
-    from six.moves.urllib.parse import urlparse  # pylint: disable=E0401
     import random
     import string
+
     from kombu.pools import connections
+    from six.moves.urllib.parse import urlparse  # pylint: disable=E0401
+
     from nameko.testing.utils import ResourcePipeline
     from nameko.utils.retry import retry
 
@@ -216,6 +219,7 @@ def rabbit_config(rabbit_uri):
 @pytest.fixture
 def rabbit_ssl_options(request):
     import os
+
     from test import on_travis
 
     ssl_options = request.config.getoption('AMQP_SSL_OPTIONS')
@@ -327,6 +331,7 @@ def container_factory():
 @pytest.fixture
 def runner_factory():
     import sys
+
     import nameko
     from nameko.runners import ServiceRunner
 
@@ -369,6 +374,7 @@ def runner_factory():
 @pytest.fixture
 def predictable_call_ids(request):
     import itertools
+
     from mock import patch
 
     with patch('nameko.standalone.rpc.uuid') as client_uuid:
@@ -414,6 +420,7 @@ def web_session(web_config_port):
 @pytest.fixture()
 def websocket(web_config_port):
     import eventlet
+
     from nameko.testing.websocket import make_virtual_socket
 
     active_sockets = []

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
             "pytest-cov==2.5.1",
             "pytest-timeout==1.3.3",
             "requests==2.28.2",
-            "urllib3==1.23",
+            "urllib3==1.26.4",
             "websocket-client==0.48.0",
         ],
         'docs': [

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'dev': [
             "coverage==5.5",
             "flake8==3.9.2",
-            "isort==4.2.15",
+            "isort==5.12.0",
             "pylint==1.9.5 ; python_version<'3'",
             "pylint==2.11.1 ; python_version>'3'",
             "pytest==4.6.11 ; python_version<'3'",

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
             "sphinxcontrib-spelling==4.2.1",
             "sphinx-nameko-theme==0.0.3",
             "docutils<0.18",  # https://github.com/sphinx-doc/sphinx/issues/9788
+            "jinja2<3.1.0",  # https://github.com/readthedocs/readthedocs.org/issues/9037
         ],
         'examples': [
             "nameko-sqlalchemy==0.0.1",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "pytest==6.2.5 ; python_version>'3'",
             "pytest-cov==2.5.1",
             "pytest-timeout==1.3.3",
-            "requests==2.19.1",
+            "requests==2.28.2",
             "urllib3==1.23",
             "websocket-client==0.48.0",
         ],

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             "pytest==6.2.5 ; python_version>'3'",
             "pytest-cov==2.5.1",
             "pytest-timeout==1.3.3",
-            "requests==2.28.2",
+            "requests==2.27.1",
             "urllib3==1.26.4",
             "websocket-client==0.48.0",
         ],

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "eventlet>=0.33.0 ; python_version>='3.10'",
         "kombu>=4.2.0",
         "kombu>=5.2.0 ; python_version>='3.10'",
+        "importlib-metadata<5 ; python_version<='3.7'; "  # https://github.com/celery/celery/issues/7783
         "mock>=1.2",
         "path.py>=6.2",
         "pyyaml>=5.1",

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ setup(
         ],
         'examples': [
             "nameko-sqlalchemy==0.0.1",
-            "PyJWT==1.5.2",
-            "moto==1.3.6",
+            "PyJWT==2.6.0",
+            "moto==4.1.2",
             "bcrypt==3.1.3",
             "regex==2018.2.21"
         ],

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
             "coverage==5.5",
             "flake8==3.9.2",
             "isort==4.3.21 ; python_version<'3'",
-            "isort==5.12.0 ; python_version>'3'",
+            "isort==5.11.5 ; python_version>'3'",
             "pylint==1.9.5 ; python_version<'3'",
             "pylint==2.11.1 ; python_version>'3'",
             "pytest==4.6.11 ; python_version<'3'",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
         'dev': [
             "coverage==5.5",
             "flake8==3.9.2",
-            "isort==5.12.0",
+            "isort==4.3.21 ; python_version<'3'",
+            "isort==5.12.0 ; python_version>'3'",
             "pylint==1.9.5 ; python_version<'3'",
             "pylint==2.11.1 ; python_version>'3'",
             "pytest==4.6.11 ; python_version<'3'",
@@ -63,8 +64,10 @@ setup(
         ],
         'examples': [
             "nameko-sqlalchemy==0.0.1",
-            "PyJWT==2.6.0",
-            "moto==4.1.2",
+            "PyJWT==1.7.1 ; python_version<'3'",
+            "PyJWT==2.6.0 ; python_version>'3'",
+            "moto==1.3.6 ; python_version<'3'",
+            "moto==4.1.2 ; python_version>'3'",
             "bcrypt==3.1.3",
             "regex==2018.2.21"
         ],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "eventlet>=0.33.0 ; python_version>='3.10'",
         "kombu>=4.2.0",
         "kombu>=5.2.0 ; python_version>='3.10'",
-        "importlib-metadata<5 ; python_version<='3.7'; "  # https://github.com/celery/celery/issues/7783
+        "importlib-metadata<5 ; python_version<='3.7'",  # https://github.com/celery/celery/issues/7783
         "mock>=1.2",
         "path.py>=6.2",
         "pyyaml>=5.1",

--- a/test/amqp/test_publish.py
+++ b/test/amqp/test_publish.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import
 
-from packaging import version
 from time import time
 
+import kombu
 import pytest
 from amqp.exceptions import (
     NotFound, PreconditionFailed, RecoverableConnectionError
 )
-import kombu
 from kombu import Connection
 from kombu.common import maybe_declare
 from kombu.compression import get_encoder
@@ -15,6 +14,7 @@ from kombu.exceptions import OperationalError
 from kombu.messaging import Exchange, Producer, Queue
 from kombu.serialization import registry
 from mock import ANY, MagicMock, Mock, call, patch
+from packaging import version
 from six.moves import queue
 from six.moves.urllib.parse import urlparse
 

--- a/test/amqp/test_publish.py
+++ b/test/amqp/test_publish.py
@@ -389,7 +389,7 @@ class TestPublisher(object):
             with pytest.raises(OperationalError):
                 publisher.publish("payload", retry=True)
 
-        if IS_LEGACY_KOMBU:
+        if IS_LEGACY_KOMBU:  # pragma: no cover
             # plus two because the first publish doesn't count as a "retry",
             # and older versions of kombu allowed one extra attemp. see
             # https://github.com/celery/kombu/commit/5bed2a8f983a3bf61c12443e7704ffd89991ef9a
@@ -416,7 +416,7 @@ class TestPublisher(object):
             'max_retries': 5
         }
 
-        if IS_LEGACY_KOMBU:
+        if IS_LEGACY_KOMBU:  # pragma: no cover
             # plus two because the first publish doesn't count as a "retry",
             # and older versions of kombu allowed one extra attemp. see
             # https://github.com/celery/kombu/commit/5bed2a8f983a3bf61c12443e7704ffd89991ef9a

--- a/test/amqp/test_publish.py
+++ b/test/amqp/test_publish.py
@@ -416,7 +416,7 @@ class TestPublisher(object):
             'max_retries': 5
         }
 
-        expected_publish_calls = publisher.retry_policy['max_retries'] + (
+        expected_publish_calls = retry_policy['max_retries'] + (
             # plus two because the first publish doesn't count as a "retry",
             # and older versions of kombu allowed one extra attempt. see
             # https://github.com/celery/kombu/commit/5bed2a8f983a3bf61c12443e7704ffd89991ef9a

--- a/test/amqp/test_publish.py
+++ b/test/amqp/test_publish.py
@@ -389,13 +389,13 @@ class TestPublisher(object):
             with pytest.raises(OperationalError):
                 publisher.publish("payload", retry=True)
 
-        if IS_LEGACY_KOMBU:  # pragma: no cover
+        expected_publish_calls = publisher.retry_policy['max_retries'] + (
             # plus two because the first publish doesn't count as a "retry",
-            # and older versions of kombu allowed one extra attemp. see
+            # and older versions of kombu allowed one extra attempt. see
             # https://github.com/celery/kombu/commit/5bed2a8f983a3bf61c12443e7704ffd89991ef9a
-            expected_publish_calls = publisher.retry_policy['max_retries'] + 2
-        else:
-            expected_publish_calls = publisher.retry_policy['max_retries'] + 1
+            2 if IS_LEGACY_KOMBU else 1   # pragma: no cover (for branches)
+        )
+
         assert mock_publish.call_count == expected_publish_calls
 
         mock_publish.reset_mock()
@@ -416,13 +416,12 @@ class TestPublisher(object):
             'max_retries': 5
         }
 
-        if IS_LEGACY_KOMBU:  # pragma: no cover
+        expected_publish_calls = publisher.retry_policy['max_retries'] + (
             # plus two because the first publish doesn't count as a "retry",
-            # and older versions of kombu allowed one extra attemp. see
+            # and older versions of kombu allowed one extra attempt. see
             # https://github.com/celery/kombu/commit/5bed2a8f983a3bf61c12443e7704ffd89991ef9a
-            expected_publish_calls = retry_policy['max_retries'] + 2
-        else:
-            expected_publish_calls = retry_policy['max_retries'] + 1
+            2 if IS_LEGACY_KOMBU else 1  # pragma: no cover (for branches)
+        )
 
         with patch.object(Producer, '_publish', new=mock_publish):
             with pytest.raises(OperationalError):

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ setenv =
     branchcoverage: ENABLE_BRANCH_COVERAGE=1
     examples: ENABLE_BRANCH_COVERAGE=1
 
-whitelist_externals = make
+allowlist_externals = make
 
 commands =
     mastereventlet: pip install --editable .[dev]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 
     # pinned library versions
     {py3.5,py3.6,py3.7}-{pinned,extra}: eventlet==0.26.0
-    {py3.10}-{pinned,extra}: eventlet==0.33.0
+    {py3.10}-{pinned,extra}: eventlet==0.33.3
     {py2.7}-pinned: kombu==4.6.11 
     {py3.5,py3.6}-pinned: kombu==5.1.0
     {py3.7,py3.9,py3.9,py3.10}-pinned: kombu==5.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     {py2.7,py3.5}-oldest: eventlet==0.20.1
     {py3.6}-oldest: eventlet==0.21.0
     {py3.7,py3.8,py3.9}-oldest: eventlet==0.25.1
-    {py3.10}-oldest: eventlet==0.33.0
+    {py3.10}-oldest: eventlet==0.33.3
     {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-oldest: kombu==4.2.0
     {py3.10}-oldest: kombu==5.2.0
     oldest: mock==1.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     {py3.7,py3.9,py3.9,py3.10}-pinned: kombu==5.2.0
     pinned: mock==2.0.0
     pinned: path.py==11.0.1
-    pinned: requests==2.19.1
+    pinned: requests==2.27.1
     pinned: six==1.11.0
     pinned: werkzeug==1.0.1
     pinned: wrapt==1.10.11


### PR DESCRIPTION
Various changes to get CI passing with updated dependencies and infra:

1. Kombu 5.2.2 fixed a bug in how retries are counted https://github.com/celery/kombu/commit/5bed2a8f983a3bf61c12443e7704ffd89991ef9a, so we account for that in test/amqp/test_publish.py
2. Eventlet 0.33.3 is now required on Python 3.10, to avoid having to pin dnspython down instead
3. No longer running tests on Python 3.7 because they're not supported on `ubuntu-latest` actions image
4. isort, moto and pyjwt (dev packages) had to be upgraded to avoid dependency conflicts
5. importlib-metadata needed pinning below 5.0 on py3.7 due to https://github.com/celery/celery/issues/7783
6. docs build needed to run on older ubuntu-20.04 actions image due to lack of `enchant` library, and to pin `jinja` to a version compatible with the old version of sphinx we use.