### PR TITLE
Fix bug in utils.retry where delay is shared between calls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         python-version:
           - 3.9
-          - 2.7
 
     steps:
     - name: checkout
@@ -47,7 +46,6 @@ jobs:
       matrix:
         python-version:
           - 3.9
-          - 2.7
     steps:
     - name: checkout
       uses: actions/checkout@v3
@@ -83,7 +81,6 @@ jobs:
           - 3.9
           - 3.8
           - 3.7
-          - 2.7
         dependency-set:
           - pinned
           - latest

--- a/nameko/utils/retry.py
+++ b/nameko/utils/retry.py
@@ -34,11 +34,9 @@ def retry(
     if max_attempts is None:
         max_attempts = float('inf')
 
-    retry_delay = RetryDelay(delay, backoff, max_delay)
-
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
-
+        retry_delay = RetryDelay(delay, backoff, max_delay)
         counter = itertools.count()
 
         while True:


### PR DESCRIPTION
If a function decorated with `utils.retry` is called more than once, the backoff shouldn't accumulate between calls