### PR TITLE
Remove dependency of dnspython<2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     url='http://github.com/nameko/nameko',
     packages=find_packages(exclude=['test', 'test.*']),
     install_requires=[
-        "dnspython<2 ; python_version<'3.10'",
         "eventlet>=0.20.1",
         "eventlet>=0.21.0 ; python_version>='3.6'",
         "eventlet>=0.25.0 ; python_version>='3.7'",


### PR DESCRIPTION
This was bothering me because this restriction is overly specific. Nowadays you want (or have) to install a much newer version of `dnspython` which conflicts with this restriction.

Tested it in my private projects with `dnspython==2.4.0` and newer for some months now, created and built a separate version which is not reflected in this pull request.