### PR TITLE
fix: deprecated field in modern werkzeug

### DIFF
--- a/nameko/web/websocket.py
+++ b/nameko/web/websocket.py
@@ -1,5 +1,7 @@
 import json
 import uuid
+import importlib
+
 from collections import namedtuple
 from functools import partial
 from logging import getLogger
@@ -26,7 +28,7 @@ from nameko.web.server import WebServer
 # all versions of werkzeug throw a 400 Bad Request error if no rules match, so we need
 # to make the explicit identification of a rule as a websocket target conditional
 # on the version of werkzeug.
-IDENTIFY_WEBSOCKET_RULES = version.parse(werkzeug.__version__) >= version.parse("2.0.0")
+IDENTIFY_WEBSOCKET_RULES = version.parse(importlib.metadata.version("werkzeug")) >= version.parse("2.0.0")
 
 
 _log = getLogger(__name__)


### PR DESCRIPTION
View: https://github.com/pallets/werkzeug/commit/40ba284a21598e67eba3faa431dc0e26a5a9c6d5#diff-ff3c479edefad986d2fe6fe7ead575a46b086e3bbcf0ccc86d85efc4a4c63c79R10

This small fix uses the built-in version parser to correctly fix the version field on modern werkzeug