### PR TITLE
Drop support for Python < 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,8 +79,6 @@ jobs:
           - "3.11"
           - "3.10"
           - 3.9
-          - 3.8
-          - 3.7
         dependency-set:
           - pinned
           - latest
@@ -90,18 +88,6 @@ jobs:
           - test
         experimental:
           - false
-        # disable experimental builds until github actions has a good way to
-        # allow failure for a job but not fail the workflow
-        # see https://github.com/actions/toolkit/issues/399.
-        # include:
-        #   - python-version: 3.7
-        #     dependency-set: latest
-        #     command: test-mastereventlet
-        #     experimental: true
-        #   - python-version: 3.7
-        #     dependency-set: latest
-        #     command: test-branchcoverage
-        #     experimental: true
 
     steps:
     - name: checkout
@@ -143,7 +129,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.11
 
     - name: install libenchant
       run: |

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,9 @@ setup(
         "click>=7.0",
         "dnspython<2 ; python_version<'3.10'",
         "eventlet>=0.20.1",
-        "eventlet>=0.21.0 ; python_version>='3.6'",
-        "eventlet>=0.25.0 ; python_version>='3.7'",
         "eventlet>=0.33.0 ; python_version>='3.10'",
         "kombu>=4.2.0",
         "kombu>=5.2.0 ; python_version>='3.10'",
-        "importlib-metadata<5 ; python_version<='3.7'",  # https://github.com/celery/celery/issues/7783
         "mock>=1.2",
         "path.py>=6.2",
         "pyyaml>=5.1",
@@ -61,38 +58,32 @@ setup(
             "docutils<0.18",  # https://github.com/sphinx-doc/sphinx/issues/9788
             "jinja2<3.1.0",  # https://github.com/readthedocs/readthedocs.org/issues/9037
         ],
-        'examples': [
+        "examples": [
             "nameko-sqlalchemy==0.0.1",
             "PyJWT==2.6.0",
             "moto==4.1.2",
             "bcrypt==3.1.3",
-            "regex==2018.2.21"
+            "regex==2018.2.21",
         ],
     },
     entry_points={
-        'console_scripts': [
-            'nameko=nameko.cli:cli',
+        "console_scripts": [
+            "nameko=nameko.cli:cli",
         ],
-        'pytest11': [
-            'pytest_nameko=nameko.testing.pytest'
-        ]
+        "pytest11": ["pytest_nameko=nameko.testing.pytest"],
     },
     zip_safe=True,
-    license='Apache License, Version 2.0',
+    license="Apache License, Version 2.0",
     classifiers=[
         "Programming Language :: Python",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Intended Audience :: Developers",
-    ]
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ setup(
             "nameko-sqlalchemy==0.0.1",
             "PyJWT==2.6.0",
             "moto==4.1.2",
+            "boto3==1.34.89",
+            "botocore==1.34.89",  # https://github.com/boto/botocore/issues/3169
             "bcrypt==3.1.3",
             "regex==2018.2.21",
         ],

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "pyyaml>=5.1",
         "requests>=1.2.0",
         "six>=1.9.0",
-        "werkzeug>=1.0.0",
+        "werkzeug>=1.0.0,<3.0",
         "wrapt>=1.0.0",
         "packaging",
     ],

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,11 @@ setup(
             "urllib3==1.26.4",
             "websocket-client==0.48.0",
         ],
-        'docs': [
-            "pyenchant==1.6.11",
-            "Sphinx==1.8.5",
-            "sphinxcontrib-spelling==4.2.1",
+        "docs": [
+            "pyenchant==3.2.2",
+            "Sphinx>=5.0",
+            "sphinxcontrib-spelling>=7.0",
             "sphinx-nameko-theme==0.0.3",
-            "docutils<0.18",  # https://github.com/sphinx-doc/sphinx/issues/9788
             "jinja2<3.1.0",  # https://github.com/readthedocs/readthedocs.org/issues/9037
         ],
         "examples": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,12 @@
 [tox]
-envlist = {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-{oldest,pinned,latest,extra}-test, {py3.5,py3.6}-latest-test-mastereventlet, py3.6-latest-test-branchcoverage, {py3.9}-examples, docs, {py3.9}-static
+envlist = {py3.9,py3.10,py3.11}-{oldest,pinned,latest,extra}-test, {py3.10,py3.11}-latest-test-mastereventlet, py3.11-latest-test-branchcoverage, {py3.11}-examples, docs, {py3.11}-static
 skipsdist = True
 
 [testenv]
 deps =
     # oldest supported libraries for each python
-    {py3.5}-oldest: eventlet==0.20.1
-    {py3.6}-oldest: eventlet==0.21.0
-    {py3.7,py3.8,py3.9}-oldest: eventlet==0.25.1
-    {py3.10,py3.11}-oldest: eventlet==0.33.3
-    {py3.5,py3.6,py3.7,py3.8,py3.9}-oldest: kombu==4.2.0
-    {py3.10,py3.11}-oldest: kombu==5.2.0
+    {py3.9,py3.10,py3.11}-oldest: eventlet==0.33.3
+    {py3.9,py3.10,py3.11}-oldest: kombu==5.2.0
     oldest: mock==1.2.0
     oldest: path.py==6.2
     oldest: requests==2.4.3
@@ -19,10 +15,8 @@ deps =
     oldest: wrapt==1.0.0
 
     # pinned library versions
-    {py3.5,py3.6,py3.7}-{pinned,extra}: eventlet==0.26.0
     {py3.10,py3.11}-{pinned,extra}: eventlet==0.33.3
-    {py3.5,py3.6}-pinned: kombu==5.1.0
-    {py3.7,py3.9,py3.9,py3.10,py3.11}-pinned: kombu==5.2.0
+    {py3.9,py3.10,py3.11}-pinned: kombu==5.2.0
     pinned: mock==2.0.0
     pinned: path.py==11.0.1
     pinned: requests==2.27.1
@@ -30,7 +24,7 @@ deps =
     pinned: werkzeug==1.0.1
     pinned: wrapt==1.10.11
 
-    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-extra: regex==2018.07.11
+    {py3.9,py3.10,py3.11}-extra: regex==2018.07.11
 
 setenv =
     branchcoverage: ENABLE_BRANCH_COVERAGE=1

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ allowlist_externals = make
 
 commands =
     mastereventlet: pip install --editable .[dev]
-    mastereventlet: pip install --upgrade https://github.com/eventlet/eventlet/archive/master.zip
+    mastereventlet: pip install --upgrade git+https://github.com/eventlet/eventlet.git@master
     mastereventlet: make test_lib
 
     static: pip install --editable .[dev]


### PR DESCRIPTION
Python versions 3.5 through 3.8 are past their EOL date. 
The next step would be to drop obsolete dependencies such as `mock` and `six`.

Fixes #781. 